### PR TITLE
Enable JAR building for FROST-Server.HTTP

### DIFF
--- a/FROST-Server.HTTP/pom.xml
+++ b/FROST-Server.HTTP/pom.xml
@@ -83,10 +83,11 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.0</version>
                 <configuration>
+                    <archiveClasses>true</archiveClasses>
+                    <attachClasses>true</attachClasses>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This enables a JAR of the classes in FROST-Server.HTTP to be created alongside the WAR.  This will make it possible for projects like Kinota Server to import classes in FROST-Server.HTTP (e.g. de.fraunhofer.iosb.ilt.sta.multipart.*) rather than having to duplicate code.