### PR TITLE
new feature: userid for PGString

### DIFF
--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/PersistenceSettings.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/PersistenceSettings.java
@@ -32,10 +32,12 @@ public class PersistenceSettings {
     private static final String TAG_IMPLEMENTATION_CLASS = "persistenceManagerImplementationClass";
     private static final String DEFAULT_IMPLEMENTATION_CLASS = "de.fraunhofer.iosb.ilt.sta.persistence.postgres.longid.PostgresPersistenceManagerLong";
     private static final String TAG_ALWAYS_ORDERBY_ID = "alwaysOrderbyId";
+    private static final String TAG_ID_GENERATION_MODE = "idGenerationMode";
 
     private static final List<String> ALL_PROPERTIES = Arrays.asList(
             TAG_IMPLEMENTATION_CLASS,
-            TAG_ALWAYS_ORDERBY_ID
+            TAG_ALWAYS_ORDERBY_ID,
+            TAG_ID_GENERATION_MODE
     );
 
     /**
@@ -43,6 +45,7 @@ public class PersistenceSettings {
      */
     private String persistenceManagerImplementationClass;
     private boolean alwaysOrderbyId = true;
+    private String idGenerationMode = "ServerGeneratedOnly";
     /**
      * Extension point for implementation specific settings
      */
@@ -58,6 +61,7 @@ public class PersistenceSettings {
     private void init(Settings settings) {
         persistenceManagerImplementationClass = settings.get(TAG_IMPLEMENTATION_CLASS, DEFAULT_IMPLEMENTATION_CLASS);
         alwaysOrderbyId = settings.getBoolean(TAG_ALWAYS_ORDERBY_ID, alwaysOrderbyId);
+        idGenerationMode = settings.get(TAG_ID_GENERATION_MODE, idGenerationMode);
         customSettings = settings;
     }
 
@@ -71,5 +75,9 @@ public class PersistenceSettings {
 
     public Settings getCustomSettings() {
         return customSettings;
+    }
+    
+    public String getIdGenerationMode() {
+        return idGenerationMode;
     }
 }

--- a/FROST-Server.HTTP/src/main/webapp/META-INF/context.xml
+++ b/FROST-Server.HTTP/src/main/webapp/META-INF/context.xml
@@ -23,6 +23,12 @@
         de.fraunhofer.iosb.ilt.sta.persistence.postgres.stringid.PostgresPersistenceManagerString
         de.fraunhofer.iosb.ilt.sta.persistence.postgres.uuidid.PostgresPersistenceManagerUuid
     -->
+    <Parameter override="false" name="persistence.idGenerationMode" value="ServerGeneratedOnly" description="Mode for id generation when using PostgresPersistenceManagerString."/>
+    <!-- All options:
+        "ServerGeneratedOnly"       = No client defined ids allowed.
+        "ServerAndClientGenerated"  = Both, server and client generated ids, are allowed.
+        "ClientGeneratedOnly"       = Client has to provide @iot.id to create entities.
+    -->
     <Parameter override="false" name="persistence.alwaysOrderbyId" value="false" description="Always add an 'orderby=id asc' to queries to ensure consistent paging."/>
     <!-- JNDO Database connection. Does suppport connection pooling. -->
     <Parameter override="false" name="persistence.db_jndi_datasource" value="jdbc/sensorThings" description="JNDI data source name"/>

--- a/FROST-Server.MQTTP/src/main/webapp/META-INF/context.xml
+++ b/FROST-Server.MQTTP/src/main/webapp/META-INF/context.xml
@@ -34,6 +34,12 @@
         de.fraunhofer.iosb.ilt.sta.persistence.postgres.stringid.PostgresPersistenceManagerString
         de.fraunhofer.iosb.ilt.sta.persistence.postgres.uuidid.PostgresPersistenceManagerUuid
     -->
+    <Parameter override="false" name="persistence.idGenerationMode" value="ServerGeneratedOnly" description="Mode for id generation when using PostgresPersistenceManagerString."/>
+    <!-- All options:
+        "ServerGeneratedOnly"       = No client defined ids allowed.
+        "ServerAndClientGenerated"  = Both, server and client generated ids, are allowed.
+        "ClientGeneratedOnly"       = Client has to provide @iot.id to create entities.
+    -->
     <Parameter override="false" name="persistence.alwaysOrderbyId" value="false" description="Always add an 'orderby=id asc' to queries to ensure consistent paging."/>
     <!-- JNDO Database connection. Does suppport connection pooling. -->
     <Parameter override="false" name="persistence.db_jndi_datasource" value="jdbc/sensorThings" description="JNDI data source name"/>

--- a/FROST-Server.SQL.PGString/src/main/java/de/fraunhofer/iosb/ilt/sta/persistence/postgres/stringid/EntityInserter.java
+++ b/FROST-Server.SQL.PGString/src/main/java/de/fraunhofer/iosb/ilt/sta/persistence/postgres/stringid/EntityInserter.java
@@ -126,6 +126,12 @@ public class EntityInserter {
         insert.set(qd.obsPropertyId, (String) op.getId().getValue());
         insert.set(qd.sensorId, (String) s.getId().getValue());
         insert.set(qd.thingId, (String) t.getId().getValue());
+        
+        IdGenerationHandler idhandler = new IdGenerationHandler(ds);
+        if (idhandler.useClientSuppliedId()) {
+            idhandler.modifyClientSuppliedId();
+            insert.set(qd.id, (String) idhandler.getIdValue());
+        }
 
         String datastreamId = insert.executeWithKey(qd.id);
         LOGGER.debug("Inserted datastream. Created id = {}.", datastreamId);
@@ -259,6 +265,12 @@ public class EntityInserter {
 
         insert.set(qd.sensorId, (String) s.getId().getValue());
         insert.set(qd.thingId, (String) t.getId().getValue());
+        
+        IdGenerationHandler idhandler = new IdGenerationHandler(ds);
+        if (idhandler.useClientSuppliedId()) {
+            idhandler.modifyClientSuppliedId();
+            insert.set(qd.id, (String) idhandler.getIdValue());
+        }
 
         String multiDatastreamId = insert.executeWithKey(qd.id);
         LOGGER.debug("Inserted multiDatastream. Created id = {}.", multiDatastreamId);
@@ -427,6 +439,12 @@ public class EntityInserter {
         String encodingType = foi.getEncodingType();
         insert.set(qfoi.encodingType, encodingType);
         insertGeometry(insert, qfoi.feature, qfoi.geom, encodingType, foi.getFeature());
+        
+        IdGenerationHandler idhandler = new IdGenerationHandler(foi);
+        if (idhandler.useClientSuppliedId()) {
+            idhandler.modifyClientSuppliedId();
+            insert.set(qfoi.id, (String) idhandler.getIdValue());
+        }
 
         String generatedId = insert.executeWithKey(qfoi.id);
         LOGGER.debug("Inserted FeatureOfInterest. Created id = {}.", generatedId);
@@ -587,6 +605,12 @@ public class EntityInserter {
         SQLInsertClause insert = qFactory.insert(qhl);
         insert.set(qhl.time, new Timestamp(h.getTime().getDateTime().getMillis()));
         insert.set(qhl.thingId, (String) h.getThing().getId().getValue());
+        
+        IdGenerationHandler idhandler = new IdGenerationHandler(h);
+        if (idhandler.useClientSuppliedId()) {
+            idhandler.modifyClientSuppliedId();
+            insert.set(qhl.id, (String) idhandler.getIdValue());
+        }
 
         String generatedId = insert.executeWithKey(qhl.id);
         LOGGER.debug("Inserted HistoricalLocation. Created id = {}.", generatedId);
@@ -665,6 +689,12 @@ public class EntityInserter {
         String encodingType = l.getEncodingType();
         insert.set(ql.encodingType, encodingType);
         insertGeometry(insert, ql.location, ql.geom, encodingType, l.getLocation());
+        
+        IdGenerationHandler idhandler = new IdGenerationHandler(l);
+        if (idhandler.useClientSuppliedId()) {
+            idhandler.modifyClientSuppliedId();
+            insert.set(ql.id, (String) idhandler.getIdValue());
+        }
 
         String locationId = insert.executeWithKey(ql.id);
         LOGGER.debug("Inserted Location. Created id = {}.", locationId);
@@ -693,6 +723,7 @@ public class EntityInserter {
             insert = qFactory.insert(qhl);
             insert.set(qhl.thingId, thingId);
             insert.set(qhl.time, new Timestamp(Calendar.getInstance().getTimeInMillis()));
+            // TODO: maybe use histLocationId based on locationId
             String histLocationId = insert.executeWithKey(qhl.id);
             LOGGER.debug("Created historicalLocation {}", histLocationId);
 
@@ -810,6 +841,7 @@ public class EntityInserter {
             insert = qFactory.insert(qhl);
             insert.set(qhl.thingId, thingId);
             insert.set(qhl.time, new Timestamp(Calendar.getInstance().getTimeInMillis()));
+            // TODO: maybe use histLocationId based on locationId
             String histLocationId = insert.executeWithKey(qhl.id);
             LOGGER.debug("Created historicalLocation {}", histLocationId);
 
@@ -900,6 +932,12 @@ public class EntityInserter {
             insert.set(qo.multiDatastreamId, (String) mds.getId().getValue());
         }
         insert.set(qo.featureId, (String) f.getId().getValue());
+        
+        IdGenerationHandler idhandler = new IdGenerationHandler(o);
+        if (idhandler.useClientSuppliedId()) {
+            idhandler.modifyClientSuppliedId();
+            insert.set(qo.id, (String) idhandler.getIdValue());
+        }
 
         String generatedId = insert.executeWithKey(qo.id);
         LOGGER.debug("Inserted Observation. Created id = {}.", generatedId);
@@ -1046,6 +1084,12 @@ public class EntityInserter {
         insert.set(qop.name, op.getName());
         insert.set(qop.description, op.getDescription());
         insert.set(qop.properties, objectToJson(op.getProperties()));
+        
+        IdGenerationHandler idhandler = new IdGenerationHandler(op);
+        if (idhandler.useClientSuppliedId()) {
+            idhandler.modifyClientSuppliedId();
+            insert.set(qop.id, (String) idhandler.getIdValue());
+        }
 
         String generatedId = insert.executeWithKey(qop.id);
         LOGGER.debug("Inserted ObservedProperty. Created id = {}.", generatedId);
@@ -1144,6 +1188,12 @@ public class EntityInserter {
         // TODO: Check metadata serialisation.
         insert.set(qs.metadata, s.getMetadata().toString());
         insert.set(qs.properties, objectToJson(s.getProperties()));
+        
+        IdGenerationHandler idhandler = new IdGenerationHandler(s);
+        if (idhandler.useClientSuppliedId()) {
+            idhandler.modifyClientSuppliedId();
+            insert.set(qs.id, (String) idhandler.getIdValue());
+        }
 
         String generatedId = insert.executeWithKey(qs.id);
         LOGGER.debug("Inserted Sensor. Created id = {}.", generatedId);
@@ -1259,6 +1309,12 @@ public class EntityInserter {
         insert.set(qt.name, t.getName());
         insert.set(qt.description, t.getDescription());
         insert.set(qt.properties, objectToJson(t.getProperties()));
+        
+        IdGenerationHandler idhandler = new IdGenerationHandler(t);
+        if (idhandler.useClientSuppliedId()) {
+            idhandler.modifyClientSuppliedId();
+            insert.set(qt.id, (String) idhandler.getIdValue());
+        }
 
         String thingId = insert.executeWithKey(qt.id);
         LOGGER.debug("Inserted Thing. Created id = {}.", thingId);
@@ -1285,6 +1341,7 @@ public class EntityInserter {
             insert = qFactory.insert(qhl);
             insert.set(qhl.thingId, thingId);
             insert.set(qhl.time, new Timestamp(Calendar.getInstance().getTimeInMillis()));
+            // TODO: maybe use histLocationId based on locationIds
             String histLocationId = insert.executeWithKey(qhl.id);
             LOGGER.debug("Created historicalLocation {}", histLocationId);
 
@@ -1414,6 +1471,7 @@ public class EntityInserter {
                 SQLInsertClause insert = qFactory.insert(qhl);
                 insert.set(qhl.thingId, thingId);
                 insert.set(qhl.time, new Timestamp(Calendar.getInstance().getTimeInMillis()));
+                // TODO: maybe use histLocationId based on locationIds
                 String histLocationId = insert.executeWithKey(qhl.id);
                 LOGGER.debug("Created historicalLocation {}", histLocationId);
 
@@ -1539,17 +1597,35 @@ public class EntityInserter {
      * complete and can thus not be created.
      */
     private void entityExistsOrCreate(Entity e) throws NoSuchEntityException, IncompleteEntityException {
-        if (e != null && e.getId() == null) {
+        if (e == null) {
+            throw new NoSuchEntityException("No entity!");
+        }
+        
+        if (e.getId() == null) {
             e.complete();
+            // no id but complete -> create
             pm.insert(e);
-        } else if (e == null || !entityExists(e)) {
-            if (e == null) {
-                throw new NoSuchEntityException("No entity!");
-            }
+            return;
+        }
+        
+        if (entityExists(e)) {
+            return;
+        }
+
+        // check if this is an incomplete entity
+        try {
+            e.complete();
+        }
+        catch (IncompleteEntityException exc) {
+            // not complete and link entity does not exist
             throw new NoSuchEntityException("No such entity '" + e.getEntityType() + "' with id " + e.getId().getValue());
         }
-    }
 
+        // complete with id -> create
+        pm.insert(e);
+        return;
+    }
+    
     public boolean entityExists(Entity e) {
         if (e == null || e.getId() == null) {
             return false;

--- a/FROST-Server.SQL.PGString/src/main/java/de/fraunhofer/iosb/ilt/sta/persistence/postgres/stringid/IdGenerationHandler.java
+++ b/FROST-Server.SQL.PGString/src/main/java/de/fraunhofer/iosb/ilt/sta/persistence/postgres/stringid/IdGenerationHandler.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2016 Fraunhofer Institut IOSB, Fraunhoferstr. 1, D 76131
+ * Karlsruhe, Germany.
+ * Copyright (C) 2018 KIT TECO, Vincenz-Prießnitz-Str. 1, D 76131
+ * Karlsruhe, Germany.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.fraunhofer.iosb.ilt.sta.persistence.postgres.stringid;
+
+import de.fraunhofer.iosb.ilt.sta.model.core.Entity;
+import de.fraunhofer.iosb.ilt.sta.util.IncompleteEntityException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * Class for handling the persistence setting "idGenerationMode".
+ * 
+ * @author koepke
+ */
+
+
+public class IdGenerationHandler {
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(IdGenerationHandler.class);
+    private static final String ERROR_MSG = "Error in IdGenerationHandler: ";
+    
+    // idGenerationType
+    private enum IdGenerationType {
+        ServerGeneratedOnly,
+        ServerAndClientGenerated,
+        ClientGeneratedOnly
+    };
+    private static IdGenerationType idGenerationMode = IdGenerationType.ServerGeneratedOnly;
+    
+    private final Entity entity;
+
+    
+    // constructor
+
+    /**
+     *
+     * Constructor for IdGenerationHandler.
+     * 
+     * @param entity Entity for which idGenerationMode should be checked/applied.
+     */
+    public IdGenerationHandler(Entity entity) {
+        this.entity = entity;
+    }
+    
+    
+    // public methods
+
+    /**
+     *
+     * Sets the idGenerationMode for all IdGenerationHandler instances.
+     * 
+     * @param mode String that contains the idGenerationMode.
+     * @throws IllegalArgumentException Will be thrown if given idGenerationMode is not supported.
+     */
+    public static void setIdGenerationMode(String mode) throws IllegalArgumentException {
+        try {
+            idGenerationMode = IdGenerationType.valueOf(mode);
+        }
+        catch (IllegalArgumentException ex) {
+            // not a valid generation mode
+            LOGGER.error(ERROR_MSG + "idGenerationMode '" + mode + "' is not supported.");
+            throw new IllegalArgumentException(ERROR_MSG + "idGenerationMode '" + mode + "' is not supported.");
+        }
+    }
+    
+    /**
+     *
+     * Returns the idvalue of the entity, which was used to create the instance of IdGeneration Handler.
+     * 
+     * @return Value of the entity id. Can be null.
+     */
+    public Object getIdValue() {
+        if (entity.getId() == null) {
+            return null;
+        }
+        else {
+            // keep null pointer for error handling
+            return entity.getId().getValue();
+        }
+    }
+    
+    /**
+     *
+     * Modify the entity id.
+     * 
+     */
+    public void modifyClientSuppliedId() {
+        if (! validateClientSuppliedId()) {
+            return;
+        }
+        
+        // add parsing here
+        // String idvalue = (String) getIdValue() + "_testing";
+        // entity.setId(new IdString(idvalue));
+    }
+    
+    /**
+     *
+     * Checks if a client generated id can/should be used with respect to the idGenerationMode.
+     * 
+     * @return true if a valid client id can be used.
+     * @throws IncompleteEntityException Will be thrown if @iot.id is missing for client generated ids.
+     * @throws IllegalArgumentException Will be thrown if idGenerationMode is not supported.
+     */
+    public boolean useClientSuppliedId() throws IncompleteEntityException, IllegalArgumentException {
+        switch(idGenerationMode) {
+            case ServerGeneratedOnly:
+                if (getIdValue() == null) {
+                    LOGGER.info("Using server generated id.");
+                    return false;
+                }
+                else {
+                    LOGGER.warn("idGenerationMode is '" + idGenerationMode.toString() + "' but @iot.id '" + getIdValue().toString() + "' is present.");
+                    return false;
+                }
+
+            case ServerAndClientGenerated:
+                if (! validateClientSuppliedId()) {
+                    LOGGER.info("No valid @iot.id. Using server generated id.");
+                    return false;
+                }
+                break;
+
+            case ClientGeneratedOnly:
+                if (! validateClientSuppliedId()) {
+                    LOGGER.error(ERROR_MSG + "No @iot.id and idGenerationMode is '" + idGenerationMode.toString() + "'");
+                    throw new IncompleteEntityException("Error: no @iot.id");
+                }
+                break;
+                
+            default:
+                // not a valid generation mode
+                LOGGER.error(ERROR_MSG + "idGenerationMode '" + idGenerationMode.toString() + "' is not supported.");
+                throw new IllegalArgumentException(ERROR_MSG + "idGenerationMode '" + idGenerationMode.toString() + "' is not supported.");
+        }
+        
+        LOGGER.info("Using client generated id.");
+        return true;
+    }
+    
+    /**
+     *
+     * Checks if a client generated id is valid.
+     * 
+     * @return true if client generated id is valid.
+     */
+    private boolean validateClientSuppliedId() {
+        if (getIdValue() == null) {
+            return false;
+        }
+        
+        // add additional checks here
+        
+        return true;
+    }
+}

--- a/FROST-Server.SQL.PGString/src/main/java/de/fraunhofer/iosb/ilt/sta/persistence/postgres/stringid/PostgresPersistenceManagerString.java
+++ b/FROST-Server.SQL.PGString/src/main/java/de/fraunhofer/iosb/ilt/sta/persistence/postgres/stringid/PostgresPersistenceManagerString.java
@@ -167,6 +167,7 @@ public class PostgresPersistenceManagerString extends AbstractPersistenceManager
     public void init(CoreSettings settings) {
         this.settings = settings;
         connectionProvider = new MyConnectionWrapper(settings);
+        IdGenerationHandler.setIdGenerationMode(settings.getPersistenceSettings().getIdGenerationMode());
     }
 
     @Override

--- a/FROST-Server.SQL.PGString/src/main/resources/liquibase/tablesString.xml
+++ b/FROST-Server.SQL.PGString/src/main/resources/liquibase/tablesString.xml
@@ -458,4 +458,32 @@
         <sqlFile dbms="postgresql" endDelimiter="/" stripComments="false" splitStatements="false" path="postgresTriggersString.sql" relativeToChangelogFile="true" encoding="utf8"/>
     </changeSet>
 
+    <changeSet author="koepke" id="20180420-alterStringTypes" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+        <sql dbms="postgresql">alter table "DATASTREAMS" alter column "ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "DATASTREAMS" alter column "SENSOR_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "DATASTREAMS" alter column "OBS_PROPERTY_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "DATASTREAMS" alter column "THING_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "FEATURES" alter column "ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "HIST_LOCATIONS" alter column "ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "HIST_LOCATIONS" alter column "THING_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "LOCATIONS" alter column "ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "LOCATIONS" alter column "GEN_FOI_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "LOCATIONS_HIST_LOCATIONS" alter column "LOCATION_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "LOCATIONS_HIST_LOCATIONS" alter column "HIST_LOCATION_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "OBS_PROPERTIES" alter column "ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "OBSERVATIONS" alter column "ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "OBSERVATIONS" alter column "DATASTREAM_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "OBSERVATIONS" alter column "FEATURE_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "SENSORS" alter column "ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "THINGS" alter column "ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "THINGS_LOCATIONS" alter column "THING_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "THINGS_LOCATIONS" alter column "LOCATION_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "MULTI_DATASTREAMS" alter column "ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "MULTI_DATASTREAMS" alter column "SENSOR_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "MULTI_DATASTREAMS" alter column "THING_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "MULTI_DATASTREAMS_OBS_PROPERTIES" alter column "MULTI_DATASTREAM_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "MULTI_DATASTREAMS_OBS_PROPERTIES" alter column "OBS_PROPERTY_ID" type varchar</sql>
+        <sql dbms="postgresql">alter table "OBSERVATIONS" alter column "MULTI_DATASTREAM_ID" type varchar</sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
I've managed to get user defined ids working without breaking the possibility of linking entities via "iot.id".
The key was to alter "entityExistsOrCreate" inside EntityInserter.
It now checks, if an entity could be a link entity before it tries to create it.

There is a new option in context.xml called "persistence.defaultIdMode" which can take on three values:
* 1: enforce standard default id mode (no user defined ids allowed)
* 2: allow both, user defined ids and default ids
* 3: enfoce user defined id mode (no default ids allowed)

Currently defaults to 2 if the option is undefined.
Loglevel for userids is set accordingly to that option.

There is a new class UserDefinedId, which encapsulates consistency checks / id parsing etc. for userids.
We plan to extend this class (again with options for default behavior) for extended user id handling like prefixing with entity type etc.

For instance, the follwing json is now a valid Thing definition:
```json
{
    "@iot.id": "MyFROSTUserId",
    "name": "Some Thing",
    "description": "Test JSON for a Thing",

    "properties": {
        "Deployment Condition": "Deployed in a third floor balcony",
        "Case Used": "Radiation shield"
    }
}
```