### PR TITLE
Create the FROST-Server Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ See [docs/settings.adoc](docs/settings.adoc) for an overview of all the the conf
 
 See [docs/docker.adoc](docs/docker.adoc) for how to use the FROST-Server docker images.
 
+## Kubernetes (Helm) support
+
+See [helm/frost-server/README.md](helm/frost-server/README.md) for how to use the FROST-Server Helm chart for a Kubernetes deployment. 
+
 ## Standalone Spring Boot
 
 If you prefer to not use Tomcat, [Kinota Server](https://github.com/kinota/kinota-server) is a

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,9 @@
+# FROST-Server Helm charts
+
+This directory contains all [Helm](https://helm.sh/) charts associated to the [FROST-Server](https://github.com/FraunhoferIOSB/FROST-Server).
+
+The table bellow lists currently available Helm charts.
+
+Chart name                          | Description
+----------------------------------- | ------------------------------------------------
+[frost-server](./frost-server)      | Main Helm chart of the full FROST-Server stack

--- a/helm/frost-server/.helmignore
+++ b/helm/frost-server/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/frost-server/Chart.yaml
+++ b/helm/frost-server/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+name: frost-server
+version: 1.7.14
+appVersion: 1.7
+description: The FROST-Server (FRaunhofer Opensource SensorThings-Server) is the first complete, open-source implementation of the OGC SensorThings API Part 1 (Sensing).
+keywords:
+  - sensorthings-api
+  - sensorthings
+  - ogc
+  - sensing
+  - iot
+  - frost
+home: https://github.com/FraunhoferIOSB/FROST-Server
+icon: https://raw.githubusercontent.com/FraunhoferIOSB/FROST-Server/master/images/FROST-Server-darkgrey.png
+sources:
+  - https://github.com/FraunhoferIOSB/FROST-Server
+mainteners:
+  - name: Aurelien Bourdon
+    url: http://abourdon.github.io

--- a/helm/frost-server/README.md
+++ b/helm/frost-server/README.md
@@ -1,0 +1,209 @@
+# FROST-Server Helm chart
+
+The [FROST-Server](https://github.com/FraunhoferIOSB/FROST-Server) (**FR**aunhofer **O**pensource **S**ensor**T**hings-Server) is the first complete, open-source implementation of the [OGC SensorThings API Part 1 (Sensing)](http://docs.opengeospatial.org/is/15-078r6/15-078r6.html).
+
+## TL;DR
+
+Declare the Helm repo or update it
+
+    $ helm repo add storeconnect https://storeconnect.github.io/helm-charts
+    $ helm repo update storeconnect
+    
+Install the FROST-Server chart
+
+    $ helm install storeconnect/frost-server  
+
+## Introduction
+
+This chart bootstraps a [FROST-Server](https://github.com/FraunhoferIOSB/FROST-Server) deployment on a [Kubernetes](https://kubernetes.io/) cluster using the [Helm](https://helm.sh/) package manager.
+
+## Prerequisites
+
+- Have a [Kubernetes](https://kubernetes.io/) 1.4+ cluster. If you do not already have a cluster, you can:
+    - Create one by using [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube)
+    - Or use [Katacoda](https://www.katacoda.com/courses/kubernetes/playground)
+    - Or use [Play with Kubernetes](http://labs.play-with-k8s.com/)
+- Have the `kubectl` command-line tool correctly configured to communicate with your Kubernetes cluster
+- Have the [`helm`](https://helm.sh/) command-line tool [correctly initialized with your Kubernetes cluster](https://docs.helm.sh/using_helm/#quickstart-guide)
+- (Optionally but recommended) Have a [Ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress/) installed on your Kubernetes cluster. Need to have [Beta APIs](https://kubernetes.io/docs/reference/using-api/api-overview/) enabled.
+
+## Installing the Chart
+
+Before to go, declare the Helm repo or update it
+    
+    $ helm repo add storeconnect https://storeconnect.github.io/helm-charts
+    $ helm repo update storeconnect
+    
+Then, to install the chart with the [release name](https://docs.helm.sh/using_helm/#quickstart-guide) `my-release`
+
+    $ helm install --name my-release storeconnect/frost-server  
+    
+This command deploys FROST-Server on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+By default, the FROST-Server instance is reachable at the `http://frost-server:30080` URL (concatenation of the `frost.http.serviceHost` and `frost.http.ports.http.servicePort` configuration values).
+
+> **Warning**: Make sure to be able to resolve the `frost-server` DNS name by adding a rule either in your DNS server or in your local DNS resolver (e.g. `/etc/hosts` in Unix-based environments), or use an IP instead of a DNS name by setting the `frost.http.serviceHost` value. 
+
+### Deployed FROST-Server resources
+
+This chart deploys a fully operational FROST-Server stack composed of:
+- A (or several, depending on the number of replicas) FROST-Server's HTTP service(s)
+- A (or several, depending on the number of replicas) FROST-Server's MQTT service(s)
+    - associated to an internal MQTT broker ([Eclipse Mosquitto](https://projects.eclipse.org/projects/technology.mosquitto))
+- (Not enabled by default) An internal FROST-Server's database
+    - associated to a local volume (disabled by default but can be enabled as explained [here](#about-persistence-support))
+
+To have a view about the deployed FROST-Server resources in the `my-release` deployment execute:
+
+    $ helm status my-release
+    
+To visualize logs about deployed Helm release's pods, execute:
+
+    $ kubeclt logs -l release=my-release
+    
+Or, more precisely: 
+
+    $ kubeclt get pods -l release=my-release
+    $ kubectl logs <pod name>
+    
+Where `<pod name>` is your desired pod name
+
+Or, even simpler, by using [kubetail](https://github.com/johanhaleby/kubetail):
+
+    $ kubetail -l release=my-release
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` release:
+
+    $ helm delete my-release
+
+This command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+    
+The following table lists the configurable parameters of the FROST-Server chart and their default values.
+
+Parameter                                   | Description                                                                                                                                                                                                                                           | Default                                                                                   
+------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- 
+`name`                                      | Override of the base name for any FROST-Server Kubernetes component                                                                                                                                                                                   | `nil` (use the chart name, `frost-server`, by default)
+`frost.http.replicas`                       | Number of FROST-Server HTTP module replicas                                                                                                                                                                                                           | `1`
+`frost.http.ports.http.nodePort`            | The external port (node port) of the FROST-Server HTTP service, **if not using Ingress**                                                                                                                                                              | `30080`
+`frost.http.ports.http.servicePort`         | The internal port of the FROST-Server HTTP module                                                                                                                                                                                                     | `80`
+`frost.http.ingress.enabled`                | If Ingress needs to be enabled for the FROST-Server HTTP module. See [bellow](#ingress) for more information                                                                                                                                          | `false`
+`frost.http.serviceHost`                    | The host used by the [`serviceRootURL`](https://github.com/FraunhoferIOSB/FROST-Server/blob/master/docs/settings.adoc#general-settings) mandatory FROST-Server configuration parameter                                                                | `frost-server`
+`frost.http.defaultCount`                   | The default value for the $count query option used by the FROST-Server HTTP module                                                                                                                                                                    | `false`
+`frost.http.defaultTop`                     | The default value for the $top query option used by the FROST-Server HTTP module                                                                                                                                                                      | `100`
+`frost.http.maxTop`                         | The maximum allowed value for the $top query option used by the FROST-Server HTTP module                                                                                                                                                              | `1000`
+`frost.http.useAbsoluteNavigationLinks`     | If `true`, FROST-Server HTTP's `navigationLinks` are absolute, otherwise relative                                                                                                                                                                     | `true`
+`frost.http.db.alwaysOrderbyId`             | Always add an `orderby=id asc` to FROST-Server HTTP's database queries to ensure consistent paging                                                                                                                                                    | `false`
+`frost.http.db.maximumConnection`           | The maximum number of database connections used by the FROST-Server HTTP module                                                                                                                                                                       | `10`
+`frost.http.db.maximumIdleConnection`       | The maximum number of idle database connections to keep open by the FROST-Server HTTP module                                                                                                                                                          | `10`
+`frost.http.db.minimumIdleConnection`       | The minimum number of idle database connections to keep open by the FROST-Server HTTP module                                                                                                                                                          | `10`
+`frost.http.bus.sendWorkerPoolSize`         | The number of FROST-Server HTTP worker threads to handle sending messages to the bus                                                                                                                                                                  | `10`
+`frost.http.bus.sendQueueSize`              | The size of the FROST-Server HTTP message queue to buffer messages to be sent to the bus                                                                                                                                                              | `100`
+`frost.http.bus.recvWorkerPoolSize`         | The number of FROST-Server HTTP worker threads to handle messages coming from the bus                                                                                                                                                                 | `10`
+`frost.http.bus.maxInFlight`                | The maximum number of FROST-Server HTTP _in-flight_ messages to allow on the MQTT bus                                                                                                                                                                 | `50`
+`frost.db.ports.postgresql.servicePort`     | The internal port of the FROST-Server database service                                                                                                                                                                                                | `5432`
+`frost.db.persistence.enabled`              | If data persistence needs to be enabled. See [bellow](#persistence) for more information                                                                                                                                                              | `false`
+`frost.db.persistence.existingClaim`        | If set, then use an existing [PersistenceVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#lifecycle-of-a-volume-and-claim) for the FROST-Server database volume. See [bellow](#persistence) for more information          | `nil` (use the builtin PersistenceVol
+`frost.db.persistence.storageClassName`     | The [StorageClassName](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class) to use by the FROST-Server database persistence. See [bellow](#persistence) for more information                                                        | `nil` (use the default StorageClass currently in use)
+`frost.db.persistence.accessModes`          | List of [AccessModes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) to claim if FROST-Server database persistence is enabled. See [bellow](#persistence) for more information                                         | `{ReadWriteOnce}`
+`frost.db.persistence.capacity`             | The storage capacity required by the FROST-Server database persistence                                                                                                                                                                                | `10Gi`
+`frost.db.persistence.local.nodeMountPath`  | The mount path to use if using the `local` StorageClassName as FROST-Server database StorageClass persistence. See [bellow](#persistence) for more information                                                                                        | `/mnt/frost-server-db`
+`frost.db.database`                         | The FROST-Server database name to use                                                                                                                                                                                                                 | `sensorthings`
+`frost.db.username`                         | The _base64_ username to use when connecting to the FROST-Server database                                                                                                                                                                             | `c2Vuc29ydGhpbmdz` (`sensorthings`)
+`frost.db.password`                         | The _base64_ password to use when connecting to the FROST-Server database                                                                                                                                                                             | `bm93eW91Y2FuY2hhbmdlaXQ=` (`nowyoucanchangeit`)
+`frost.db.idGenerationMode`                 | Determines how entity ids are generated by any FROST-Server module. See [here](https://github.com/FraunhoferIOSB/FROST-Server/blob/master/docs/settings.adoc#persistence-settings) for more information                                               | `ServerGeneratedOnly`
+`frost.db.implementationClass`              | The Java class used for persistence by any FROST-Server module                                                                                                                                                                                        | `[...].PostgresPersistenceManagerLong` (see [1] bellow for the complete value) 
+`frost.mqtt.enabled`                        | If MQTT support needs to be enabled. See [bellow](#mqtt) for more information                                                                                                                                                                         | `true`
+`frost.mqtt.replicas`                       | The number of FROST-Server MQTT module replicas                                                                                                                                                                                                       | `1`
+`frost.mqtt.ports.mqtt.nodePort`            | The external port (node port) of the FROST-Server MQTT service                                                                                                                                                                                        | `30883`
+`frost.mqtt.ports.mqtt.servicePort`         | The internal port of the FROST-Server MQTT service                                                                                                                                                                                                    | `1883`
+`frost.mqtt.ports.websocket.nodePort`       | The external port (node port) of the FROST-Server MQTT websocket service                                                                                                                                                                              | `30876`
+`frost.mqtt.ports.websocket.servicePort`    | The internal port of the FROST-Server MQTT websocket service                                                                                                                                                                                          | `9876`
+`frost.mqtt.stickySessionTimeout`           | Timeout (in seconds) of sticky time sessions used by the FROST-Server MQTT server                                                                                                                                                                     | `10800` (3 hours)
+`frost.mqtt.qos`                            | Quality of Service Level for MQTT messages                                                                                                                                                                                                            | `2`
+`frost.mqtt.subscribeMessageQueueSize`      | Queue size for messages to be published via MQTT                                                                                                                                                                                                      | `100`
+`frost.mqtt.subscribeThreadPoolSize`        | Number of threads use to dispatch MQTT notifications                                                                                                                                                                                                  | `10`
+`frost.mqtt.createMessageQueueSize`         | Queue size for create observation requests via MQTT                                                                                                                                                                                                   | `100`
+`frost.mqtt.createThreadPoolSize`           | Number of threads use to dispatch observation creation requests                                                                                                                                                                                       | `10`
+`frost.mqtt.maxInFlight`                    | The maximum number of _in-flight_ messages to allow when sending notifications                                                                                                                                                                        | `50`
+`frost.mqtt.db.alwaysOrderbyId`             | Always add an `orderby=id asc` to to FROST-Server MQTT's database queries to ensure consistent paging                                                                                                                                                 | `false`
+`frost.mqtt.db.maximumConnection`           | The maximum number of database connections to use by the FROST-Server MQTT module                                                                                                                                                                     | `10`
+`frost.mqtt.db.maximumIdleConnection`       | The maximum number of idle database connections to keep open by the FROST-Server MQTT module                                                                                                                                                          | `10`
+`frost.mqtt.db.minimumIdleConnection`       | The minimum number of idle database connections to keep open by the FROST-Server MQTT module                                                                                                                                                          | `10`
+`frost.mqtt.bus.sendWorkerPoolSize`         | The number of FROST-Server MQTT worker threads to handle sending messages to the MQTT bus                                                                                                                                                             | `10`
+`frost.mqtt.bus.sendQueueSize`              | The size of the FROST-Server MQTT message queue to buffer messages to be sent to the MQTT bus                                                                                                                                                         | `100`
+`frost.mqtt.bus.recvWorkerPoolSize`         | The number of FROST-Server MQTT worker threads to handle messages coming from the MQTT bus                                                                                                                                                            | `10`
+`frost.mqtt.bus.maxInFlight`                | The maximum number of FROST-Server MQTT _in-flight_ messages to allow on the MQTT bus                                                                                                                                                                 | `50`
+`frost.bus.ports.bus.servicePort`           | The internal port of the FROST-Server Messages Bus service                                                                                                                                                                                            | `1883`
+`frost.bus.implementationClass`             | The Java class that is used to connect to the message bus, common for any FROST-Server modules                                                                                                                                                        | `[...].MqttMessageBus` (see [2] bellow for the complete value)
+`frost.bus.topicName`                       | The MQTT topic to use as a message bus by any FROST-Server module                                                                                                                                                                                     | `FROST-Bus`
+`frost.bus.qosLevel`                        | The Quality of Service Level for the MQTT bus by any FROST-Server module                                                                                                                                                                              | `2`
+
+> [1] The complete default `frost.db.implementationClass` value is `de.fraunhofer.iosb.ilt.sta.persistence.postgres.longid.PostgresPersistenceManagerLong`.
+
+> [2] The complete default `frost.bus.implementationClass` value is `de.fraunhofer.iosb.ilt.sta.messagebus.MqttMessageBus`.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm` `install|upgrade`. For example,
+
+    $ helm install --name my-release \
+        --set key_1=value_1,key_2=value_2 \
+        storeconnect/frost-server
+        
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+    # example for staging
+    $ helm install --name my-release -f values.yaml storeconnect/frost-server  
+
+> **Tip**: You can use the default [values.yaml](./values.yaml)
+
+More information about the FROST-Server configuration can be found [here](https://github.com/FraunhoferIOSB/FROST-Server/blob/master/docs/settings.adoc). 
+
+## MQTT
+
+As described in the [OGC SensorThings API specification](http://docs.opengeospatial.org/is/15-078r6/15-078r6.html#85), MQTT support is an optional extension but enabled by default in the FROST-Server Helm chart.
+To disable MQTT support, override the `frost.mqtt.enabled` configuration value to `false`. 
+
+    $ helm install --set frost.mqtt.enabled=false storeconnect/frost-server
+
+## Persistence
+
+By default, the FROST-Server database is working without data persistence. Thus, if the Helm release or the FROST-Server database pod is deleted, then all saved data is lost.
+To enable data persistence, turn on the `frost.db.persistence.enabled` configuration parameter:
+
+    $ helm install --set frost.db.persistence.enabled=true storeconnect/frost-server
+
+Once FROST-Server database persistence is enabled, then the FROST-Server will either:
+- use its own [PersistenceVolumeClaim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#lifecycle-of-a-volume-and-claim), which is described bellow
+- or use an existing PersistenceVolumeClaim, if the `frost.db.persistence.existingClaim` is set
+
+If persistence is enabled and no existing PersistenceVolumeClaim is defined (`frost.db.persistence.existingClaim` is unset), then the FROST-Server chart will claim a [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) that fits with its associated [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) name.
+By default, no name is defined, then the default StorageClass currently in use in the Kubernetes cluster will be used.
+But you can override this behaviour by setting the `frost.db.persistence.storageClassName` configuration value with your desired StorageClass name to use. 
+
+If necessary, the FROST-Server chart also defines its own StorageClass name, `frost-server-db-local`, bound to a [builtin local volume](./templates/db-local-volume.yaml), which stores data in a local directory within the cluster (more precisely within the node where this local volume is deployed).
+To enable it, set the `frost.db.persistence.storageClassName` to `frost-server-db-local` and precise the folder where data need to be persisted on the node
+
+    $ helm install \
+        --set frost.db.persistence.enabled=true,frost.db.persistence.storageClassName=frost-server-db-local,frost.db.persistence.local.nodeMountPath=/mnt/frost-server-db \
+        storeconnect/frost-server
+
+> **Warning #1**: The `local` StorageClass cannot be scaled.
+
+> **Warning #2**: The `local` StorageClass can only be used if only the ReadWriteOnce [AccessMode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) is claimed (check the `frost.db.persistence.accessModes` configuration parameter).
+
+## Ingress
+
+The FROST-Server HTTP component can be accessed through an [Ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress/). By default, Ingress is disabled but can be enabled thanks to the `frost.http.ingress.enabled` option:
+
+    $ helm install --set frost.http.ingress.enabled=true storeconnect/frost-server
+    
+Or if you want to enable it in your current living `my-release` release:
+    
+    $ helm upgrade --set frost.http.ingress.enabled=true my-release storeconnect/frost-server
+    
+Once Ingress is enabled on the FROST-Server HTTP component, then the FROST-Server HTTP API can be accessed at `http://<frost.http.serviceHost>` (`http://frost-server` by default), on the standard 80 HTTP port, without being constrained to specify the `frost.http.ports.http.nodePort` port.
+
+ > **Warning**: `frost.http.serviceHost` needs to be a DNS name. Make sure to be able to resolve it by adding a rule either in your DNS server or in your local DNS resolver (e.g. `/etc/hosts` in Unix-based environments).

--- a/helm/frost-server/templates/NOTES.txt
+++ b/helm/frost-server/templates/NOTES.txt
@@ -1,0 +1,37 @@
+Your FROST-Server v.{{ .Chart.AppVersion }} "{{ .Release.Name }}" release is now running.
+
+**************************************************************************************************
+
+IMPORTANT
+
+    The FROST-Server HTTP API is reachable at {{ include "frost-server.http.serviceRootUrl" . }}
+
+    In case of using a DNS name for the FROST-Server HTTP API host, make sure to be able to resolve it by
+    adding a rule either to your DNS server or your local DNS resolver (e.g. /etc/hosts in Unix-based environments).
+
+    In case of a fresh database installation, you have to initialize it before using FROST-Server's services.
+    You can do either by:
+        - Browsing to {{ include "frost-server.http.serviceRootUrl" . }}/DatabaseStatus and clicking on the "Do Update" button
+        - Or executing a POST request to {{ include "frost-server.http.serviceRootUrl" . }}/DatabaseStatus
+{{- if not .Values.frost.db.persistence.enabled }}
+
+/!\ WARNING /!\
+
+    FROST-Server database is working without persistence. You will lose your data when the FROST-Server database pod is terminated.
+    To enable persistence, set the "frost.db.persistence.enabled" configuration parameter to "true".
+{{- end }}
+
+**************************************************************************************************
+
+Hereafter the list of available exposed FROST-Server's resources:
+
+FROST-Server's resource     | Access URL
+--------------------------- | ----------------------------------------------
+HTTP - Homepage             | {{ include "frost-server.http.serviceRootUrl" . }}
+HTTP - SensorThings API     | {{ include "frost-server.http.serviceRootUrl" . }}/{{ include "frost-server.http.apiVersion" . }}
+{{- if .Values.frost.mqtt.enabled }}
+MQTT - TCP                  | {{ .Values.frost.http.serviceHost }}:{{ .Values.frost.mqtt.ports.mqtt.nodePort }}
+MQTT - Websocket            | {{ .Values.frost.http.serviceHost }}:{{ .Values.frost.mqtt.ports.websocket.nodePort }}
+{{- end }}
+
+For more information about FROST-Server, please visit https://github.com/FraunhoferIOSB/FROST-Server

--- a/helm/frost-server/templates/_helpers.tpl
+++ b/helm/frost-server/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "frost-server.name" -}}
+{{- default .Chart.Name .Values.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "frost-server.fullName" -}}
+{{- $name := default .Chart.Name .Values.name -}}
+{{- if .tier -}}
+{{- printf "%s-%s-%s" .Release.Name $name .tier | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "frost-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Get the HTTP service API version
+*/}}
+{{- define "frost-server.http.apiVersion" -}}
+v1.0
+{{- end -}}
+
+{{/*
+Get the HTTP service root URL
+*/}}
+{{- define "frost-server.http.serviceRootUrl" -}}
+http://{{ .Values.frost.http.serviceHost }}{{ if not .Values.frost.http.ingress.enabled }}:{{ .Values.frost.http.ports.http.nodePort }}{{ end }}
+{{- end -}}

--- a/helm/frost-server/templates/bus-deployment.yaml
+++ b/helm/frost-server/templates/bus-deployment.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.frost.mqtt.enabled -}}
+{{- $tier := "bus" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+spec:
+  selector:
+    matchLabels:
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+      chart: {{ include "frost-server.chart" . }}
+      app: {{ include "frost-server.name" . }}
+      component: {{ $tier }}
+  template:
+    metadata:
+      labels:
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        chart: {{ include "frost-server.chart" . }}
+        app: {{ include "frost-server.name" . }}
+        component: {{ $tier }}
+    spec:
+      containers:
+        - name: {{ $fullName }}
+          image: eclipse-mosquitto:1.4.12
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: mqtt
+              containerPort: 1883
+{{- end -}}

--- a/helm/frost-server/templates/bus-service.yaml
+++ b/helm/frost-server/templates/bus-service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.frost.mqtt.enabled -}}
+{{- $tier := "bus" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+spec:
+  selector:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+  ports:
+    - name: mqtt
+      port: {{ .Values.frost.bus.ports.bus.servicePort }}
+      targetPort: mqtt
+{{- end -}}

--- a/helm/frost-server/templates/db-deployment.yaml
+++ b/helm/frost-server/templates/db-deployment.yaml
@@ -1,0 +1,60 @@
+{{- $tier := "db" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+spec:
+  selector:
+    matchLabels:
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+      chart: {{ include "frost-server.chart" . }}
+      app: {{ include "frost-server.name" . }}
+      component: {{ $tier }}
+  template:
+    metadata:
+      labels:
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        chart: {{ include "frost-server.chart" . }}
+        app: {{ include "frost-server.name" . }}
+        component: {{ $tier }}
+    spec:
+      containers:
+        - name: {{ $fullName }}
+          image: mdillon/postgis:10
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          {{- if .Values.frost.db.persistence.enabled }}
+          volumeMounts:
+            - name: {{ $fullName }}
+              mountPath: /var/lib/postgresql/data
+          {{- end }}
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.frost.db.database }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "frost-server.fullName" . }}
+                  key: db.username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "frost-server.fullName" . }}
+                  key: db.password
+      {{- if .Values.frost.db.persistence.enabled }}
+      volumes:
+        - name: {{ $fullName }}
+          persistentVolumeClaim:
+            claimName: {{ default $fullName .Values.frost.db.persistence.existingClaim }}
+      {{- end -}}

--- a/helm/frost-server/templates/db-local-volume.yaml
+++ b/helm/frost-server/templates/db-local-volume.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.frost.db.persistence.enabled -}}
+{{- if .Values.frost.db.persistence.storageClassName -}}
+{{- if eq .Values.frost.db.persistence.storageClassName "frost-server-db-local" -}}
+{{- $tier := "db-local-volume" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ $fullName }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+spec:
+  storageClassName: frost-server-db-local
+  capacity:
+    storage: {{ .Values.frost.db.persistence.capacity }}
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: {{ .Values.frost.db.persistence.local.nodeMountPath }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/frost-server/templates/db-service.yaml
+++ b/helm/frost-server/templates/db-service.yaml
@@ -1,0 +1,23 @@
+{{- $tier := "db" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+spec:
+  selector:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+  ports:
+    - name: postgresql
+      port: {{ .Values.frost.db.ports.postgresql.servicePort }}
+      targetPort: postgresql

--- a/helm/frost-server/templates/db-volume-claim.yaml
+++ b/helm/frost-server/templates/db-volume-claim.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.frost.db.persistence.enabled (not .Values.frost.db.persistence.existingClaim) -}}
+{{- $tier := "db" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullName }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+spec:
+  {{- if .Values.frost.db.persistence.storageClassName }}
+  storageClassName: {{ .Values.frost.db.persistence.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.frost.db.persistence.capacity }}
+  accessModes:
+  {{- range .Values.frost.db.persistence.accessModes }}
+    - {{ . }}
+  {{- end }}
+{{- end -}}

--- a/helm/frost-server/templates/http-deployment.yaml
+++ b/helm/frost-server/templates/http-deployment.yaml
@@ -1,0 +1,122 @@
+{{- $tier := "http" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+spec:
+  selector:
+    matchLabels:
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+      chart: {{ include "frost-server.chart" . }}
+      app: {{ include "frost-server.name" . }}
+      component: {{ $tier }}
+  replicas: {{ .Values.frost.http.replicas }}
+  template:
+    metadata:
+      labels:
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        chart: {{ include "frost-server.chart" . }}
+        app: {{ include "frost-server.name" . }}
+        component: {{ $tier }}
+    spec:
+      containers:
+        - name: {{ $fullName }}
+          image: fraunhoferiosb/frost-server-http:1.7
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: tomcat
+              containerPort: 8080
+          env:
+            # Internal properties
+            - name: ApiVersion
+              value: {{ include "frost-server.http.apiVersion" . | quote }}
+            - name: serviceRootUrl
+              value: {{ include "frost-server.http.serviceRootUrl" . | quote }}
+
+            # HTTP related properties
+            - name: defaultCount
+              value: "{{ .Values.frost.http.defaultCount }}"
+            - name: defaultTop
+              value: "{{ .Values.frost.http.defaultTop }}"
+            - name: maxTop
+              value: "{{ .Values.frost.http.maxTop }}"
+            - name: maxDataSize
+              value: "{{ .Values.frost.http.maxDataSize | int64 }}"
+            - name: useAbsoluteNavigationLinks
+              value: "{{ .Values.frost.http.useAbsoluteNavigationLinks }}"
+
+            {{ if .Values.frost.mqtt.enabled -}}
+            # Messages bus related properties
+            - name: bus_mqttBroker
+              value: {{ printf "tcp://%s:1883" (include "frost-server.fullName" (merge (dict "tier" "bus") .)) | quote }}
+            - name: bus_busImplementationClass
+              value: "{{ .Values.frost.bus.implementationClass }}"
+            - name: bus_topicName
+              value: "{{ .Values.frost.bus.topicName }}"
+            - name: bus_qosLevel
+              value: "{{ .Values.frost.bus.qos }}"
+            - name: bus_sendWorkerPoolSize
+              value: "{{ .Values.frost.http.bus.sendWorkerPoolSize }}"
+            - name: bus_sendQueueSize
+              value: "{{ .Values.frost.http.bus.sendQueueSize }}"
+            - name: bus_recvWorkerPoolSize
+              value: "{{ .Values.frost.http.bus.recvWorkerPoolSize }}"
+            - name: bus_recvQueueSize
+              value: "{{ .Values.frost.http.bus.recvQueueSize }}"
+            - name: bus_maxInFlight
+              value: "{{ .Values.frost.http.bus.maxInFlight }}"
+            {{- end }}
+
+            # Persistence related properties
+            - name: persistence_db_jndi_datasource
+              value: ""
+            - name: persistence_db_driver
+              value: "org.postgresql.Driver"
+            - name: persistence_db_url
+              value: {{ printf "jdbc:postgresql://%s:5432/%s" (include "frost-server.fullName" (merge (dict "tier" "db") .)) .Values.frost.db.database | quote }}
+            - name: persistence_persistenceManagerImplementationClass
+              value: "{{ .Values.frost.db.implementationClass }}"
+            - name: persistence_idGenerationMode
+              value: "{{ .Values.frost.db.idGenerationMode }}"
+            - name: persistence_alwaysOrderbyId
+              value: "{{ .Values.frost.http.db.alwaysOrderbyId }}"
+            - name: persistence_db_conn_max
+              value: "{{ .Values.frost.http.db.maximumConnection }}"
+            - name: persistence_db_conn_idle_max
+              value: "{{ .Values.frost.http.db.maximumIdleConnection }}"
+            - name: persistence_db_conn_idle_min
+              value: "{{ .Values.frost.http.db.maximumIdleConnection }}"
+            - name: persistence_db_username
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "frost-server.fullName" . }}
+                  key: db.username
+            - name: persistence_db_password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "frost-server.fullName" . }}
+                  key: db.password
+
+          # Execute some operations before to launch the FROST-Server HTTP's WAR:
+          #   1. Remove all existing Tomcat webapps
+          #   2. Set the access to the FROST-Server HTTP API at the Tomcat's root
+          #   3. Clean environment (remove the unnecessary WAR)
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - >
+              mv /usr/local/tomcat/webapps/FROST-Server.war /tmp
+              && rm -rf /usr/local/tomcat/webapps/*
+              && unzip -d /usr/local/tomcat/webapps/ROOT /tmp/FROST-Server.war
+              && rm /tmp/FROST-Server.war
+              && catalina.sh run

--- a/helm/frost-server/templates/http-ingress.yaml
+++ b/helm/frost-server/templates/http-ingress.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.frost.http.ingress.enabled -}}
+{{- $tier := "http" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+spec:
+  rules:
+  - host: {{ .Values.frost.http.serviceHost }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ $fullName }}
+          servicePort: {{ .Values.frost.http.ports.http.servicePort }}
+{{- end -}}

--- a/helm/frost-server/templates/http-service.yaml
+++ b/helm/frost-server/templates/http-service.yaml
@@ -1,0 +1,29 @@
+{{- $tier := "http" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+spec:
+  selector:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+  {{- if not .Values.frost.http.ingress.enabled }}
+  type: NodePort
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.frost.http.ports.http.servicePort }}
+      {{- if not .Values.frost.http.ingress.enabled }}
+      nodePort: {{ .Values.frost.http.ports.http.nodePort }}
+      {{- end }}
+      targetPort: tomcat

--- a/helm/frost-server/templates/mqtt-deployment.yaml
+++ b/helm/frost-server/templates/mqtt-deployment.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.frost.mqtt.enabled -}}
+{{- $tier := "mqtt" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+spec:
+  selector:
+    matchLabels:
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+      chart: {{ include "frost-server.chart" . }}
+      app: {{ include "frost-server.name" . }}
+      component: {{ $tier }}
+  replicas: {{ .Values.frost.mqtt.replicas }}
+  template:
+    metadata:
+      labels:
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+        chart: {{ include "frost-server.chart" . }}
+        app: {{ include "frost-server.name" . }}
+        component: {{ $tier }}
+    spec:
+      containers:
+        - name: {{ $fullName }}
+          image: fraunhoferiosb/frost-server-mqtt:1.7
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: mqtt
+              containerPort: 1883
+            - name: websocket
+              containerPort: 9876
+          env:
+            # Internal properties
+            - name: ApiVersion
+              value: {{ include "frost-server.http.apiVersion" . | quote }}
+            - name: serviceRootUrl
+              value: {{ include "frost-server.http.serviceRootUrl" . | quote }}
+
+            # HTTP related properties
+            - name: defaultCount
+              value: "{{ .Values.frost.http.defaultCount }}"
+            - name: defaultTop
+              value: "{{ .Values.frost.http.defaultTop }}"
+            - name: maxTop
+              value: "{{ .Values.frost.http.maxTop }}"
+            - name: maxDataSize
+              value: "{{ .Values.frost.http.maxDataSize | int64 }}"
+            - name: useAbsoluteNavigationLinks
+              value: "{{ .Values.frost.http.useAbsoluteNavigationLinks }}"
+
+            # MQTT related properties
+            - name: mqtt_mqttServerImplementationClass
+              value: "de.fraunhofer.iosb.ilt.sensorthingsserver.mqtt.moquette.MoquetteMqttServer"
+            - name: mqtt_Enabled
+              value: "true"
+            - name: mqtt_Port
+              value: "1883"
+            - name: mqtt_Host
+              value: "0.0.0.0"
+            - name: mqtt_internalHost
+              value: "localhost"
+            - name: mqtt_WebsocketPort
+              value: "9876"
+            - name: mqtt_WaitForEnter
+              value: "false"
+            - name: mqtt_QoS
+              value: "{{ .Values.frost.mqtt.qos }}"
+            - name: mqtt_SubscribeMessageQueueSize
+              value: "{{ .Values.frost.mqtt.subscribeMessageQueueSize }}"
+            - name: mqtt_SubscribeThreadPoolSize
+              value: "{{ .Values.frost.mqtt.subscribeThreadPoolSize }}"
+            - name: mqtt_CreateMessageQueueSize
+              value: "{{ .Values.frost.mqtt.createMessageQueueSize }}"
+            - name: mqtt_CreateThreadPoolSize
+              value: "{{ .Values.frost.mqtt.createThreadPoolSize }}"
+            - name: mqtt_maxInFlight
+              value: "{{ .Values.frost.mqtt.maxInFlight }}"
+
+            # Messages bus related properties
+            - name: bus_mqttBroker
+              value: {{ printf "tcp://%s:1883" (include "frost-server.fullName" (merge (dict "tier" "bus") .)) | quote }}
+            - name: bus_busImplementationClass
+              value: "{{ .Values.frost.bus.implementationClass }}"
+            - name: bus_topicName
+              value: "{{ .Values.frost.bus.topicName }}"
+            - name: bus_qosLevel
+              value: "{{ .Values.frost.bus.qos }}"
+            - name: bus_sendWorkerPoolSize
+              value: "{{ .Values.frost.mqtt.bus.sendWorkerPoolSize }}"
+            - name: bus_sendQueueSize
+              value: "{{ .Values.frost.mqtt.bus.sendQueueSize }}"
+            - name: bus_recvWorkerPoolSize
+              value: "{{ .Values.frost.mqtt.bus.recvWorkerPoolSize }}"
+            - name: bus_recvQueueSize
+              value: "{{ .Values.frost.mqtt.bus.recvQueueSize }}"
+            - name: bus_maxInFlight
+              value: "{{ .Values.frost.mqtt.bus.maxInFlight }}"
+
+            # Persistence related properties
+            - name: persistence_db_jndi_datasource
+              value: ""
+            - name: persistence_db_driver
+              value: "org.postgresql.Driver"
+            - name: persistence_db_url
+              value: {{ printf "jdbc:postgresql://%s:5432/%s" (include "frost-server.fullName" (merge (dict "tier" "db") .)) .Values.frost.db.database | quote }}
+            - name: persistence_persistenceManagerImplementationClass
+              value: "{{ .Values.frost.db.implementationClass }}"
+            - name: persistence_idGenerationMode
+              value: "{{ .Values.frost.db.idGenerationMode }}"
+            - name: persistence_alwaysOrderbyId
+              value: "{{ .Values.frost.mqtt.db.alwaysOrderbyId }}"
+            - name: persistence_db_conn_max
+              value: "{{ .Values.frost.mqtt.db.maximumConnection }}"
+            - name: persistence_db_conn_idle_max
+              value: "{{ .Values.frost.mqtt.db.maximumIdleConnection }}"
+            - name: persistence_db_conn_idle_min
+              value: "{{ .Values.frost.mqtt.db.minimumIdleConnection }}"
+            - name: persistence_db_username
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "frost-server.fullName" . }}
+                  key: db.username
+            - name: persistence_db_password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "frost-server.fullName" . }}
+                  key: db.password
+{{- end -}}

--- a/helm/frost-server/templates/mqtt-service.yaml
+++ b/helm/frost-server/templates/mqtt-service.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.frost.mqtt.enabled -}}
+{{- $tier := "mqtt" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+spec:
+  selector:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+    component: {{ $tier }}
+  type: NodePort
+  ports:
+    - name: mqtt
+      port: {{ .Values.frost.mqtt.ports.mqtt.servicePort }}
+      nodePort: {{ .Values.frost.mqtt.ports.mqtt.nodePort }}
+      targetPort: mqtt
+    - name: websocket
+      port: {{ .Values.frost.mqtt.ports.websocket.servicePort }}
+      nodePort: {{ .Values.frost.mqtt.ports.websocket.nodePort }}
+      targetPort: websocket
+  # MQTT server stores the subscriptions and the client should connect to the same server after the connection is lost
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.frost.mqtt.stickySessionTimeout }}
+{{- end -}}

--- a/helm/frost-server/templates/secret.yaml
+++ b/helm/frost-server/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "frost-server.fullName" . }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ include "frost-server.chart" . }}
+    app: {{ include "frost-server.name" . }}
+data:
+  db.username: {{ .Values.frost.db.username }}
+  db.password: {{ .Values.frost.db.password }}

--- a/helm/frost-server/values.yaml
+++ b/helm/frost-server/values.yaml
@@ -1,0 +1,121 @@
+# If empty, use the chart name as common base name for any FROST-Server Kubernetes component
+name:
+
+frost:
+  ##########################################
+  # FROST-Server HTTP module configuration #
+  ##########################################
+  http:
+    # FROST-Server HTTP deployment settings
+    replicas: 1
+    ports:
+      http:
+        nodePort: 30080
+        servicePort: 80
+    ingress:
+      enabled: false
+
+    # FROST-Server HTTP business settings
+    serviceHost: frost-server
+    defaultCount: false
+    defaultTop: 100
+    maxTop: 1000
+    maxDataSize: 25000000
+    useAbsoluteNavigationLinks: true
+
+    # FROST-Server Database related settings to the FROST-Server HTTP
+    db:
+      alwaysOrderbyId: false
+      maximumConnection: 10
+      maximumIdleConnection: 10
+      minimumIdleConnection: 10
+
+    # FROST-Server Messages Bus related settings to the FROST-Server HTTP
+    bus:
+      sendWorkerPoolSize: 10
+      sendQueueSize: 100
+      recvWorkerPoolSize: 10
+      recvQueueSize: 100
+      maxInFlight: 50
+
+  ##############################################
+  # FROST-Server Database module configuration #
+  ##############################################
+  db:
+    # FROST-Server Database deployment settings
+    ports:
+      postgresql:
+        servicePort: 5432
+    persistence:
+      enabled: false
+      existingClaim:
+      storageClassName:
+      accessModes:
+        - ReadWriteOnce
+      capacity: 10Gi
+      # Uncomment bellow if you want to use the builtin "frost-server-db-local" StorageClass name.
+      # Only compatible if the ReadWriteOnce access mode is only claimed (check the frost.db.persistence.accessModes value).
+      # See project documentation for more information
+      #local:
+      #  nodeMountPath: /mnt/frost-server-db
+
+    # Common FROST-Server Database properties, shared by any other FROST-Server modules
+    implementationClass: "de.fraunhofer.iosb.ilt.sta.persistence.postgres.longid.PostgresPersistenceManagerLong"
+    idGenerationMode: "ServerGeneratedOnly"
+    database: sensorthings
+    username: c2Vuc29ydGhpbmdz
+    password: bm93eW91Y2FuY2hhbmdlaXQ=
+
+  ##########################################
+  # FROST-Server MQTT module configuration #
+  ##########################################
+  mqtt:
+    # FROST-Server MQTT deployment settings
+    enabled: true
+    replicas: 1
+    ports:
+      mqtt:
+        nodePort: 30883
+        servicePort: 1883
+      websocket:
+        nodePort: 30876
+        servicePort: 9876
+    stickySessionTimeout: 10800
+
+    # FROST-Server MQTT business settings
+    qos: 2
+    subscribeMessageQueueSize: 100
+    subscribeThreadPoolSize: 10
+    createMessageQueueSize: 100
+    createThreadPoolSize: 10
+    maxInFlight: 50
+    waitForEnter: false
+
+    # FROST-Server Database related settings to the FROST-Server MQTT
+    db:
+      alwaysOrderbyId: false
+      maximumConnection: 10
+      maximumIdleConnection: 10
+      minimumIdleConnection: 10
+
+    # FROST-Server Messages Bus related settings to the FROST-Server MQTT
+    bus:
+      sendWorkerPoolSize: 10
+      sendQueueSize: 100
+      recvWorkerPoolSize: 10
+      recvQueueSize: 100
+      maxInFlight: 50
+
+  ##################################################
+  # FROST-Server Messages Bus module configuration #
+  ##################################################
+  bus:
+    # FROST-Server Messages Bus deployment settings
+    ports:
+      bus:
+        servicePort: 1883
+
+    # Common FROST-Server Messages Bus properties, shared by any other FROST-Server modules
+    implementationClass: "de.fraunhofer.iosb.ilt.sta.messagebus.MqttMessageBus"
+    topicName: "FROST-Bus"
+    qos: 2


### PR DESCRIPTION
Hi,

Please accept this PR that creates the [Helm](https://helm.sh/) chart of FROST-Server for a [Kubernetes](https://kubernetes.io/) deployment.

Any additional information about this work can be found in its associated [issue](https://github.com/FraunhoferIOSB/FROST-Server/issues/61).

Last thing to do: this Helm chart is currently deployed into a [non official Helm repository](https://storeconnect.github.io/helm-charts). To do things properly, it could be very nice to create the official FROST Helm chart repository and update documentation accordingly.

Closes #61