### PR TITLE
Fix logic error in ConfigDefaults.configDefaults()

### DIFF
--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigDefaults.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigDefaults.java
@@ -109,8 +109,10 @@ public interface ConfigDefaults {
                 defaultValue = Integer.toString(f.getAnnotation(DefaultValueInt.class).value());
             }
             try {
-                String key = f.get(this).toString();
-                configDefaults.put(key, defaultValue);
+                if (defaultValue != null) {
+                    String key = f.get(this).toString();
+                    configDefaults.put(key, defaultValue);
+                }
             } catch (IllegalAccessException e) {
                 LOGGER.warn("Unable to access field '" +
                         f.getName() + "' on object: " + this);


### PR DESCRIPTION
Fix bug where non-annotated fields were mistakenly included in the Map returned by `configDefaults()`.