### PR TITLE
Reduce overhead of calls to defaultValue() and defaultValueInt()

### DIFF
--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigDefaults.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigDefaults.java
@@ -19,6 +19,7 @@ package de.fraunhofer.iosb.ilt.sta.settings;
 
 import de.fraunhofer.iosb.ilt.sta.settings.annotation.DefaultValue;
 import de.fraunhofer.iosb.ilt.sta.settings.annotation.DefaultValueInt;
+
 import java.lang.reflect.*;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,7 +44,28 @@ public interface ConfigDefaults {
      * was not so annotated.
      */
     default public String defaultValue(String fieldValue) {
-        return configDefaults().getOrDefault(fieldValue, "");
+        for (Field f : this.getClass().getFields()) {
+            if (f.isAnnotationPresent(DefaultValue.class)) {
+                try {
+                    if (f.get(this).toString().equals(fieldValue)) {
+                        return f.getAnnotation(DefaultValue.class).value();
+                    }
+                } catch (IllegalAccessException e) {
+                    LOGGER.warn("Unable to access field '"
+                            + f.getName() + "' on object: " + this);
+                }
+            } else if (f.isAnnotationPresent(DefaultValueInt.class)) {
+                try {
+                    if (f.get(this).toString().equals(fieldValue)) {
+                        return Integer.toString(f.getAnnotation(DefaultValueInt.class).value());
+                    }
+                } catch (IllegalAccessException e) {
+                    LOGGER.warn("Unable to access field '"
+                            + f.getName() + "' on object: " + this);
+                }
+            }
+        }
+        return "";
     }
 
     /**
@@ -53,7 +75,19 @@ public interface ConfigDefaults {
      * was not so annotated.
      */
     default public int defaultValueInt(String fieldValue) {
-        return configDefaultsInt().getOrDefault(fieldValue, 0);
+        for (Field f : this.getClass().getFields()) {
+            if (f.isAnnotationPresent(DefaultValueInt.class)) {
+                try {
+                    if (f.get(this).toString().equals(fieldValue)) {
+                        return Integer.valueOf(f.getAnnotation(DefaultValueInt.class).value());
+                    }
+                } catch (IllegalAccessException e) {
+                    LOGGER.warn("Unable to access field '"
+                            + f.getName() + "' on object: " + this);
+                }
+            }
+        }
+        return 0;
     }
 
     /**

--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigUtils.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigUtils.java
@@ -117,4 +117,60 @@ public class ConfigUtils {
         }
         return configDefaults;
     }
+
+    /**
+     * Returns the default value of a field annotated with either
+     * {@link DefaultValue} or {@link DefaultValueInt}.
+     *
+     * @param target The class to get the config default for.
+     * @param fieldValue The value of the annotated field
+     * @return The default value of the annotated field, or empty string (e.g.
+     * "") if the field was not so annotated.
+     */
+    public static String getDefaultValue(ConfigDefaults target, String fieldValue) {
+        for (final Field f : target.getClass().getFields()) {
+            if (f.isAnnotationPresent(DefaultValue.class)) {
+                try {
+                    if (f.get(target).toString().equals(fieldValue)) {
+                        return f.getAnnotation(DefaultValue.class).value();
+                    }
+                } catch (IllegalAccessException e) {
+                    LOGGER.warn(UNABLE_TO_ACCESS_FIELD_ON_OBJECT, f.getName(), target);
+                }
+            } else if (f.isAnnotationPresent(DefaultValueInt.class)) {
+                try {
+                    if (f.get(target).toString().equals(fieldValue)) {
+                        return Integer.toString(f.getAnnotation(DefaultValueInt.class).value());
+                    }
+                } catch (IllegalAccessException e) {
+                    LOGGER.warn(UNABLE_TO_ACCESS_FIELD_ON_OBJECT, f.getName(), target);
+                }
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Returns the default value of a field annotated with
+     * {@link DefaultValueInt}.
+     *
+     * @param target The class to get the config default for.
+     * @param fieldValue The value of the annotated field
+     * @return The default value of the annotated field, or 0 if the field was
+     * not so annotated.
+     */
+    public static int getDefaultValueInt(ConfigDefaults target, String fieldValue) {
+        for (final Field f : target.getClass().getFields()) {
+            if (f.isAnnotationPresent(DefaultValueInt.class)) {
+                try {
+                    if (f.get(target).toString().equals(fieldValue)) {
+                        return Integer.valueOf(f.getAnnotation(DefaultValueInt.class).value());
+                    }
+                } catch (IllegalAccessException e) {
+                    LOGGER.warn(UNABLE_TO_ACCESS_FIELD_ON_OBJECT, f.getName(), target);
+                }
+            }
+        }
+        return 0;
+    }
 }


### PR DESCRIPTION
Replace calls to `ConfigUtils.getConfigDefaults()` and `ConfigUtils.getConfigDefaultsInt()` with calls to `ConfigUtils.getDefaultValue()` or `ConfigUtils.getDefaultValueInt()` which are new functions that get the default values using a linear search rather than scanning all fields and building a map of annotated fields.  This linear search approach will be more efficient for repeated calls to `ConfigDefaults.defaultValue*`.  Caching the annotated field maps is not practicable because ConfigDefaults is an interface (which I think we want it to be), so it cannot contain private static fields, so doing something like storing the maps in a singleton instance won't work; requiring implementing classes to do this would add a lot boilerplate, which we are trying to avoid.  I think the linear search will be fine as the cardinality of annotated fields will be low (i.e. <100 in nearly all cases).