### PR TITLE
Refactor ConfigUtils methods to accept classes instead of instances

### DIFF
--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigDefaults.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigDefaults.java
@@ -20,8 +20,6 @@ package de.fraunhofer.iosb.ilt.sta.settings;
 import de.fraunhofer.iosb.ilt.sta.settings.annotation.DefaultValue;
 import de.fraunhofer.iosb.ilt.sta.settings.annotation.DefaultValueInt;
 
-import java.lang.reflect.*;
-
 import java.util.Map;
 import java.util.Set;
 
@@ -42,7 +40,7 @@ public interface ConfigDefaults {
      * "") if the field was not so annotated.
      */
     default String defaultValue(String fieldValue) {
-        return ConfigUtils.getDefaultValue(this, fieldValue);
+        return ConfigUtils.getDefaultValue(this.getClass(), fieldValue);
     }
 
     /**
@@ -54,7 +52,7 @@ public interface ConfigDefaults {
      * not so annotated.
      */
     default int defaultValueInt(String fieldValue) {
-        return ConfigUtils.getDefaultValueInt(this, fieldValue);
+        return ConfigUtils.getDefaultValueInt(this.getClass(), fieldValue);
     }
 
     /**
@@ -64,7 +62,7 @@ public interface ConfigDefaults {
      * @return The list of field names so annotated.
      */
     default Set<String> configTags() {
-        return ConfigUtils.getConfigTags(this);
+        return ConfigUtils.getConfigTags(this.getClass());
     }
 
     /**
@@ -74,7 +72,7 @@ public interface ConfigDefaults {
      * @return Mapping of config tag value and default value
      */
     default Map<String, String> configDefaults() {
-        return ConfigUtils.getConfigDefaults(this);
+        return ConfigUtils.getConfigDefaults(this.getClass());
     }
 
     /**
@@ -84,6 +82,6 @@ public interface ConfigDefaults {
      * @return Mapping of config tag value and default value
      */
     default Map<String, Integer> configDefaultsInt() {
-        return ConfigUtils.getConfigDefaultsInt(this);
+        return ConfigUtils.getConfigDefaultsInt(this.getClass());
     }
 }

--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigUtils.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigUtils.java
@@ -19,12 +19,14 @@ package de.fraunhofer.iosb.ilt.sta.settings;
 
 import de.fraunhofer.iosb.ilt.sta.settings.annotation.DefaultValue;
 import de.fraunhofer.iosb.ilt.sta.settings.annotation.DefaultValueInt;
+
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,9 +55,9 @@ public class ConfigUtils {
      * @param target The class to get the config field names for.
      * @return The list of field names so annotated.
      */
-    public static Set<String> getConfigTags(ConfigDefaults target) {
+    public static <T extends ConfigDefaults> Set<String> getConfigTags(Class<T> target) {
         Set<String> configTags = new HashSet<>();
-        for (Field f : target.getClass().getFields()) {
+        for (Field f : target.getFields()) {
             try {
                 if (f.isAnnotationPresent(DefaultValue.class) || f.isAnnotationPresent(DefaultValueInt.class)) {
                     configTags.add(f.get(target).toString());
@@ -75,9 +77,9 @@ public class ConfigUtils {
      * @param target The class to get the config fields for.
      * @return Mapping of config tag value and default value
      */
-    public static Map<String, String> getConfigDefaults(ConfigDefaults target) {
+    public static <T extends ConfigDefaults> Map<String, String> getConfigDefaults(Class<T> target) {
         Map<String, String> configDefaults = new HashMap<>();
-        for (Field f : target.getClass().getFields()) {
+        for (Field f : target.getFields()) {
             String defaultValue = null;
             if (f.isAnnotationPresent(DefaultValue.class)) {
                 defaultValue = f.getAnnotation(DefaultValue.class).value();
@@ -103,9 +105,9 @@ public class ConfigUtils {
      * @param target The class to get the config fields for.
      * @return Mapping of config tag value and default value
      */
-    public static Map<String, Integer> getConfigDefaultsInt(ConfigDefaults target) {
+    public static <T extends ConfigDefaults> Map<String, Integer> getConfigDefaultsInt(Class<T> target) {
         Map<String, Integer> configDefaults = new HashMap<>();
-        List<Field> fields = FieldUtils.getFieldsListWithAnnotation(target.getClass(), DefaultValueInt.class);
+        List<Field> fields = FieldUtils.getFieldsListWithAnnotation(target, DefaultValueInt.class);
         for (Field f : fields) {
             try {
                 configDefaults.put(
@@ -127,8 +129,8 @@ public class ConfigUtils {
      * @return The default value of the annotated field, or empty string (e.g.
      * "") if the field was not so annotated.
      */
-    public static String getDefaultValue(ConfigDefaults target, String fieldValue) {
-        for (final Field f : target.getClass().getFields()) {
+    public static <T extends ConfigDefaults> String getDefaultValue(Class<T> target, String fieldValue) {
+        for (final Field f : target.getFields()) {
             if (f.isAnnotationPresent(DefaultValue.class)) {
                 try {
                     if (f.get(target).toString().equals(fieldValue)) {
@@ -159,12 +161,12 @@ public class ConfigUtils {
      * @return The default value of the annotated field, or 0 if the field was
      * not so annotated.
      */
-    public static int getDefaultValueInt(ConfigDefaults target, String fieldValue) {
-        for (final Field f : target.getClass().getFields()) {
+    public static <T extends ConfigDefaults> int getDefaultValueInt(Class<T> target, String fieldValue) {
+        for (final Field f : target.getFields()) {
             if (f.isAnnotationPresent(DefaultValueInt.class)) {
                 try {
                     if (f.get(target).toString().equals(fieldValue)) {
-                        return Integer.valueOf(f.getAnnotation(DefaultValueInt.class).value());
+                        return f.getAnnotation(DefaultValueInt.class).value();
                     }
                 } catch (IllegalAccessException e) {
                     LOGGER.warn(UNABLE_TO_ACCESS_FIELD_ON_OBJECT, f.getName(), target);

--- a/FROST-Server.Core/src/test/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigDefaultsTest.java
+++ b/FROST-Server.Core/src/test/java/de/fraunhofer/iosb/ilt/sta/settings/ConfigDefaultsTest.java
@@ -82,4 +82,50 @@ public class ConfigDefaultsTest {
         assertEquals("2", configDefaults.get(b.TAG_QOS_LEVEL));
         assertEquals("50", configDefaults.get(b.TAG_MAX_IN_FLIGHT));
     }
+
+    @Test
+    public void testDefaultValueLookupClass() {
+        Class c = MqttMessageBus.class;
+        // Test valid integer properties
+        assertEquals(2, ConfigUtils.getDefaultValueInt(c, TAG_SEND_WORKER_COUNT));
+        assertEquals(2, ConfigUtils.getDefaultValueInt(c, TAG_RECV_WORKER_COUNT));
+        assertEquals(100, ConfigUtils.getDefaultValueInt(c, TAG_SEND_QUEUE_SIZE));
+        assertEquals(100, ConfigUtils.getDefaultValueInt(c, TAG_RECV_QUEUE_SIZE));
+        assertEquals(2, ConfigUtils.getDefaultValueInt(c, TAG_QOS_LEVEL));
+        assertEquals(50, ConfigUtils.getDefaultValueInt(c, TAG_MAX_IN_FLIGHT));
+        // Test valid string properties
+        assertEquals("tcp://127.0.0.1:1884", ConfigUtils.getDefaultValue(c, TAG_MQTT_BROKER));
+        assertEquals("FROST-Bus", ConfigUtils.getDefaultValue(c, TAG_TOPIC_NAME));
+        // Test reading integer properties as strings
+        assertEquals("2", ConfigUtils.getDefaultValue(c, TAG_SEND_WORKER_COUNT));
+        assertEquals("2", ConfigUtils.getDefaultValue(c, TAG_RECV_WORKER_COUNT));
+        assertEquals("100", ConfigUtils.getDefaultValue(c, TAG_SEND_QUEUE_SIZE));
+        assertEquals("100", ConfigUtils.getDefaultValue(c, TAG_RECV_QUEUE_SIZE));
+        assertEquals("2", ConfigUtils.getDefaultValue(c, TAG_QOS_LEVEL));
+        assertEquals("50", ConfigUtils.getDefaultValue(c, TAG_MAX_IN_FLIGHT));
+        // Test invalid properties
+        assertEquals(0, ConfigUtils.getDefaultValueInt(c,"NOT_A_VALID_INT_PROPERTY"));
+        assertEquals("", ConfigUtils.getDefaultValue(c, "NOT_A_VALID_STR_PROPERTY"));
+        // Test configTags
+        Set<String> tags = new HashSet<>();
+        tags.add(TAG_SEND_WORKER_COUNT);
+        tags.add(TAG_RECV_WORKER_COUNT);
+        tags.add(TAG_SEND_QUEUE_SIZE);
+        tags.add(TAG_RECV_QUEUE_SIZE);
+        tags.add(TAG_QOS_LEVEL);
+        tags.add(TAG_MAX_IN_FLIGHT);
+        tags.add(TAG_MQTT_BROKER);
+        tags.add(TAG_TOPIC_NAME);
+        assertTrue(tags.equals(ConfigUtils.getConfigTags(c)));
+        // Test configDefaults
+        Map<String, String> configDefaults = ConfigUtils.getConfigDefaults(c);
+        assertEquals("tcp://127.0.0.1:1884", configDefaults.get(TAG_MQTT_BROKER));
+        assertEquals("FROST-Bus", configDefaults.get(TAG_TOPIC_NAME));
+        assertEquals("2", configDefaults.get(TAG_SEND_WORKER_COUNT));
+        assertEquals("2", configDefaults.get(TAG_RECV_WORKER_COUNT));
+        assertEquals("100", configDefaults.get(TAG_SEND_QUEUE_SIZE));
+        assertEquals("100", configDefaults.get(TAG_RECV_QUEUE_SIZE));
+        assertEquals("2", configDefaults.get(TAG_QOS_LEVEL));
+        assertEquals("50", configDefaults.get(TAG_MAX_IN_FLIGHT));
+    }
 }


### PR DESCRIPTION
Refactor ConfigUtils methods to accept classes instead of instances.  This allows for easy lookup of default configuration options across classes.