### PR TITLE
Handled MQTT client connection lost

### DIFF
--- a/FROST-Server.MQTT.Moquette/src/main/java/de/fraunhofer/iosb/ilt/sensorthingsserver/mqtt/moquette/MoquetteMqttServer.java
+++ b/FROST-Server.MQTT.Moquette/src/main/java/de/fraunhofer/iosb/ilt/sensorthingsserver/mqtt/moquette/MoquetteMqttServer.java
@@ -115,12 +115,17 @@ public class MoquetteMqttServer implements MqttServer, ConfigDefaults {
         if (mqttBroker != null && client != null) {
             if (!client.isConnected()) {
                 LOGGER.warn("MQTT client is not connected while trying to publish.");
-            } else {
                 try {
-                    client.publish(topic, payload, qos, false);
+                    client.reconnect();
                 } catch (MqttException ex) {
-                    LOGGER.error("publish on topic '" + topic + "' failed.", ex);
+                    LOGGER.warn("MQTT client failed to reconnect.");
+                    return;
                 }
+            }
+            try {
+                client.publish(topic, payload, qos, false);
+            } catch (MqttException ex) {
+                LOGGER.error("publish on topic '" + topic + "' failed.", ex);
             }
         }
     }
@@ -274,6 +279,7 @@ public class MoquetteMqttServer implements MqttServer, ConfigDefaults {
             client = new MqttClient(broker, frostClientId, new MemoryPersistence());
             MqttConnectOptions connOpts = new MqttConnectOptions();
             connOpts.setCleanSession(true);
+            connOpts.setAutomaticReconnect(true);
             connOpts.setKeepAliveInterval(30);
             connOpts.setConnectionTimeout(30);
             connOpts.setMaxInflight(maxInFlight);


### PR DESCRIPTION
In my usage of the FROST-Server, sometimes the internal MQTT client of FROST-Server might lose connection. 

In that case, the whole FROST-Server must be restarted in order to bring the connection back. Only restarting my external MQTT client won't help. I keep seeing the message "MQTT client is not connected while trying to publish." after I restarted my external MQTT client.

So I tried to let the internal MQTT client automatically reconnect if the connection is lost. The two functions I called are documented here:

- [`connOpts.setAutomaticReconnect()`](https://www.eclipse.org/paho/files/javadoc/org/eclipse/paho/client/mqttv3/MqttConnectOptions.html#setAutomaticReconnect-boolean-)
- [`client.reconnect()`](https://www.eclipse.org/paho/files/javadoc/org/eclipse/paho/client/mqttv3/MqttClient.html#reconnect--)