### PR TITLE
removed maven.compiler.release for java8 without --release support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,8 @@
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
 
         <bintray.subject>fraunhoferiosb</bintray.subject>
         <bintray.repo>Maven</bintray.repo>
@@ -157,9 +158,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
-                    <configuration>
-                        <release>${maven.compiler.release}</release>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-war-plugin</artifactId>


### PR DESCRIPTION
mvn compile fails with "invalid flag: --release" when using still commonly used java8 (e.g. openjdk version "1.8.0_212"), because javac in java8 does not have a --release flag.
