### PR TITLE
Update PostgreSQL triggers in order to consider MultiDatastreams

### DIFF
--- a/FROST-Server.SQLjooq/src/main/resources/liquibase/postgresTriggers.sql
+++ b/FROST-Server.SQLjooq/src/main/resources/liquibase/postgresTriggers.sql
@@ -56,30 +56,57 @@ drop trigger if exists datastreams_actualization_insert ON "OBSERVATIONS";
 
 -- ---------------------------------------
 -- Function: datastreams_update_insert()
+--
+-- This function also updates multidatastreams. Updated fields are:
+-- PHENOMENON_TIME_START,PHENOMENON_TIME_END,RESULT_TIME_START,RESULT_TIME_END and OBSERVED_AREA
 -- ---------------------------------------
 create or replace function datastreams_update_insert()
   returns trigger as
 $BODY$
 declare
 "DS_ROW" "DATASTREAMS"%rowtype;
+"MDS_ROW" "MULTI_DATASTREAMS"%rowtype;
 begin
 
-select * into "DS_ROW" from "DATASTREAMS" where "DATASTREAMS"."ID"=NEW."DATASTREAM_ID";
-if (NEW."PHENOMENON_TIME_START"<"DS_ROW"."PHENOMENON_TIME_START" or "DS_ROW"."PHENOMENON_TIME_START" is null) then
-    update "DATASTREAMS" set "PHENOMENON_TIME_START" = NEW."PHENOMENON_TIME_START" where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-end if;
-if (coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") > "DS_ROW"."PHENOMENON_TIME_END" or "DS_ROW"."PHENOMENON_TIME_END" is null) then
-    update "DATASTREAMS" set "PHENOMENON_TIME_END" = coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+if (NEW."DATASTREAM_ID" is not null) 
+then 
+	select * into "DS_ROW" from "DATASTREAMS" where "DATASTREAMS"."ID"=NEW."DATASTREAM_ID";
+	if (NEW."PHENOMENON_TIME_START"<"DS_ROW"."PHENOMENON_TIME_START" or "DS_ROW"."PHENOMENON_TIME_START" is null) then
+		update "DATASTREAMS" set "PHENOMENON_TIME_START" = NEW."PHENOMENON_TIME_START" where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+	end if;
+	if (coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") > "DS_ROW"."PHENOMENON_TIME_END" or "DS_ROW"."PHENOMENON_TIME_END" is null) then
+		update "DATASTREAMS" set "PHENOMENON_TIME_END" = coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+	end if;
+
+	if (NEW."RESULT_TIME"<"DS_ROW"."RESULT_TIME_START" or "DS_ROW"."RESULT_TIME_START" is null) then
+		update "DATASTREAMS" set "RESULT_TIME_START" = NEW."RESULT_TIME" where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+	end if;
+	if (NEW."RESULT_TIME" > "DS_ROW"."RESULT_TIME_END" or "DS_ROW"."RESULT_TIME_END" is null) then
+		update "DATASTREAMS" set "RESULT_TIME_END" = NEW."RESULT_TIME" where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+	end if;
+
+	update "DATASTREAMS" SET "OBSERVED_AREA" = ST_ConvexHull(ST_Collect("OBSERVED_AREA", (select "GEOM" from "FEATURES" where "ID"=NEW."FEATURE_ID"))) where "DATASTREAMS"."ID"=NEW."DATASTREAM_ID";
 end if;
 
-if (NEW."RESULT_TIME"<"DS_ROW"."RESULT_TIME_START" or "DS_ROW"."RESULT_TIME_START" is null) then
-    update "DATASTREAMS" set "RESULT_TIME_START" = NEW."RESULT_TIME" where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-end if;
-if (NEW."RESULT_TIME" > "DS_ROW"."RESULT_TIME_END" or "DS_ROW"."RESULT_TIME_END" is null) then
-    update "DATASTREAMS" set "RESULT_TIME_END" = NEW."RESULT_TIME" where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-end if;
+if (NEW."MULTI_DATASTREAM_ID" is not null) 
+then 
+	select * into "MDS_ROW" from "MULTI_DATASTREAMS" where "MULTI_DATASTREAMS"."ID"=NEW."MULTI_DATASTREAM_ID";
+	if (NEW."PHENOMENON_TIME_START"<"MDS_ROW"."PHENOMENON_TIME_START" or "MDS_ROW"."PHENOMENON_TIME_START" is null) then
+		update "MULTI_DATASTREAMS" set "PHENOMENON_TIME_START" = NEW."PHENOMENON_TIME_START" where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+	end if;
+	if (coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") > "MDS_ROW"."PHENOMENON_TIME_END" or "MDS_ROW"."PHENOMENON_TIME_END" is null) then
+		update "MULTI_DATASTREAMS" set "PHENOMENON_TIME_END" = coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+	end if;
 
-update "DATASTREAMS" SET "OBSERVED_AREA" = ST_ConvexHull(ST_Collect("OBSERVED_AREA", (select "GEOM" from "FEATURES" where "ID"=NEW."FEATURE_ID"))) where "DATASTREAMS"."ID"=NEW."DATASTREAM_ID";
+	if (NEW."RESULT_TIME"<"MDS_ROW"."RESULT_TIME_START" or "MDS_ROW"."RESULT_TIME_START" is null) then
+		update "MULTI_DATASTREAMS" set "RESULT_TIME_START" = NEW."RESULT_TIME" where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+	end if;
+	if (NEW."RESULT_TIME" > "MDS_ROW"."RESULT_TIME_END" or "MDS_ROW"."RESULT_TIME_END" is null) then
+		update "MULTI_DATASTREAMS" set "RESULT_TIME_END" = NEW."RESULT_TIME" where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+	end if;
+
+	update "MULTI_DATASTREAMS" SET "OBSERVED_AREA" = ST_ConvexHull(ST_Collect("OBSERVED_AREA", (select "GEOM" from "FEATURES" where "ID"=NEW."FEATURE_ID"))) where "MULTI_DATASTREAMS"."ID"=NEW."MULTI_DATASTREAM_ID";
+end if;
 
 return new;
 END
@@ -105,62 +132,125 @@ drop trigger if exists datastreams_actualization_update ON "OBSERVATIONS";
 
 -- ---------------------------------------
 -- Function: datastreams_update_update()
+--
+-- This function also updates multidatastreams. Updated fields are:
+-- PHENOMENON_TIME_START,PHENOMENON_TIME_END,RESULT_TIME_START,RESULT_TIME_END.
+-- Warning: OBSERVED_AREA not taken into account. 
 -- ---------------------------------------
 create or replace function datastreams_update_update()
   returns trigger as
 $BODY$
 declare
 "DS_ROW" "DATASTREAMS"%rowtype;
+"MDS_ROW" "MULTI_DATASTREAMS"%rowtype;
 begin
 
-if (NEW."PHENOMENON_TIME_START" != OLD."PHENOMENON_TIME_START" or NEW."PHENOMENON_TIME_END" != OLD."PHENOMENON_TIME_END") then
-    for "DS_ROW" in select * from "DATASTREAMS" where "ID"=NEW."DATASTREAM_ID"
-    loop
-        if (NEW."PHENOMENON_TIME_START"<"DS_ROW"."PHENOMENON_TIME_START") then
-            update "DATASTREAMS" set "PHENOMENON_TIME_START" = NEW."PHENOMENON_TIME_START" where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-        end if;
-        if (coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") > "DS_ROW"."PHENOMENON_TIME_END") then
-            update "DATASTREAMS" set "PHENOMENON_TIME_END" = coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-        end if;
+if (NEW."DATASTREAM_ID" is not null) 
+then 
+	if (NEW."PHENOMENON_TIME_START" != OLD."PHENOMENON_TIME_START" or NEW."PHENOMENON_TIME_END" != OLD."PHENOMENON_TIME_END") then
+		for "DS_ROW" in select * from "DATASTREAMS" where "ID"=NEW."DATASTREAM_ID"
+		loop
+			if (NEW."PHENOMENON_TIME_START"<"DS_ROW"."PHENOMENON_TIME_START") then
+				update "DATASTREAMS" set "PHENOMENON_TIME_START" = NEW."PHENOMENON_TIME_START" where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+			end if;
+			if (coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") > "DS_ROW"."PHENOMENON_TIME_END") then
+				update "DATASTREAMS" set "PHENOMENON_TIME_END" = coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+			end if;
 
-        if (OLD."PHENOMENON_TIME_START" = "DS_ROW"."PHENOMENON_TIME_START"
-            or coalesce(OLD."PHENOMENON_TIME_END", OLD."PHENOMENON_TIME_START") = "DS_ROW"."PHENOMENON_TIME_END")
-        then
-            update "DATASTREAMS"
-                set "PHENOMENON_TIME_START" = (select min("PHENOMENON_TIME_START") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
-                where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-            update "DATASTREAMS"
-                set "PHENOMENON_TIME_END" = (select max(coalesce("PHENOMENON_TIME_END", "PHENOMENON_TIME_START")) from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
-                where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-        end if;
-    end loop;
-    return NEW;
+			if (OLD."PHENOMENON_TIME_START" = "DS_ROW"."PHENOMENON_TIME_START"
+				or coalesce(OLD."PHENOMENON_TIME_END", OLD."PHENOMENON_TIME_START") = "DS_ROW"."PHENOMENON_TIME_END")
+			then
+				update "DATASTREAMS"
+					set "PHENOMENON_TIME_START" = (select min("PHENOMENON_TIME_START") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
+					where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+				update "DATASTREAMS"
+					set "PHENOMENON_TIME_END" = (select max(coalesce("PHENOMENON_TIME_END", "PHENOMENON_TIME_START")) from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
+					where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+			end if;
+		end loop;
+		return NEW;
+	end if;
+
+
+	if (NEW."RESULT_TIME" != OLD."RESULT_TIME") then
+		for "DS_ROW" in select * from "DATASTREAMS" where "ID"=NEW."DATASTREAM_ID"
+		loop
+			if (NEW."RESULT_TIME" < "DS_ROW"."RESULT_TIME_START") then
+				update "DATASTREAMS" set "RESULT_TIME_START" = NEW."RESULT_TIME" where "ID" = "DS_ROW"."ID";
+			end if;
+			if (NEW."RESULT_TIME" > "DS_ROW"."RESULT_TIME_END") then
+				update "DATASTREAMS" set "RESULT_TIME_END" = NEW."RESULT_TIME" where "ID" = "DS_ROW"."ID";
+			end if;
+
+			if (OLD."RESULT_TIME" = "DS_ROW"."RESULT_TIME_START")
+			then
+				update "DATASTREAMS"
+					set "RESULT_TIME_START" = (select min("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
+					where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+			end if;
+			if (OLD."RESULT_TIME" = "DS_ROW"."RESULT_TIME_END")
+			then
+				update "DATASTREAMS"
+					set "RESULT_TIME_END" = (select max("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
+					where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+			end if;
+		end loop;
+		return NEW;
+	end if;
 end if;
 
-if (NEW."RESULT_TIME" != OLD."RESULT_TIME") then
-    for "DS_ROW" in select * from "DATASTREAMS" where "ID"=NEW."DATASTREAM_ID"
-    loop
-        if (NEW."RESULT_TIME" < "DS_ROW"."RESULT_TIME_START") then
-            update "DATASTREAMS" set "RESULT_TIME_START" = NEW."RESULT_TIME" where "ID" = "DS_ROW"."ID";
-        end if;
-        if (NEW."RESULT_TIME" > "DS_ROW"."RESULT_TIME_END") then
-            update "DATASTREAMS" set "RESULT_TIME_END" = NEW."RESULT_TIME" where "ID" = "DS_ROW"."ID";
-        end if;
+if (NEW."MULTI_DATASTREAM_ID" is not null) 
+then 
+	if (NEW."PHENOMENON_TIME_START" != OLD."PHENOMENON_TIME_START" or NEW."PHENOMENON_TIME_END" != OLD."PHENOMENON_TIME_END") then
+		select * into "MDS_ROW" from "MULTI_DATASTREAMS" where "MULTI_DATASTREAMS"."ID"=NEW."MULTI_DATASTREAM_ID";
+		
+		if (NEW."PHENOMENON_TIME_START"<"MDS_ROW"."PHENOMENON_TIME_START") then
+			update "MULTI_DATASTREAMS" set "PHENOMENON_TIME_START" = NEW."PHENOMENON_TIME_START" where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+		end if;
+		if (coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") > "MDS_ROW"."PHENOMENON_TIME_END") then
+			update "MULTI_DATASTREAMS" set "PHENOMENON_TIME_END" = coalesce(NEW."PHENOMENON_TIME_END", NEW."PHENOMENON_TIME_START") where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+		end if;
 
-        if (OLD."RESULT_TIME" = "DS_ROW"."RESULT_TIME_START")
-        then
-            update "DATASTREAMS"
-                set "RESULT_TIME_START" = (select min("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
-                where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-        end if;
-        if (OLD."RESULT_TIME" = "DS_ROW"."RESULT_TIME_END")
-        then
-            update "DATASTREAMS"
-                set "RESULT_TIME_END" = (select max("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
-                where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-        end if;
-    end loop;
-    return NEW;
+		if (OLD."PHENOMENON_TIME_START" = "MDS_ROW"."PHENOMENON_TIME_START"
+			or coalesce(OLD."PHENOMENON_TIME_END", OLD."PHENOMENON_TIME_START") = "MDS_ROW"."PHENOMENON_TIME_END")
+		then
+			update "MULTI_DATASTREAMS"
+				set "PHENOMENON_TIME_START" = (select min("PHENOMENON_TIME_START") from "OBSERVATIONS" where "OBSERVATIONS"."MULTI_DATASTREAM_ID" = "MDS_ROW"."ID")
+				where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+			update "MULTI_DATASTREAMS"
+				set "PHENOMENON_TIME_END" = (select max(coalesce("PHENOMENON_TIME_END", "PHENOMENON_TIME_START")) from "OBSERVATIONS" where "OBSERVATIONS"."MULTI_DATASTREAM_ID" = "MDS_ROW"."ID")
+				where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+		end if;
+		
+		return NEW;
+	end if;
+
+
+	if (NEW."RESULT_TIME" != OLD."RESULT_TIME") then
+		select * into "MDS_ROW" from "MULTI_DATASTREAMS" where "MULTI_DATASTREAMS"."ID"=NEW."MULTI_DATASTREAM_ID";
+		
+		if (NEW."RESULT_TIME" < "MDS_ROW"."RESULT_TIME_START") then
+			update "MULTI_DATASTREAMS" set "RESULT_TIME_START" = NEW."RESULT_TIME" where "ID" = "MDS_ROW"."ID";
+		end if;
+		if (NEW."RESULT_TIME" > "MDS_ROW"."RESULT_TIME_END") then
+			update "MULTI_DATASTREAMS" set "RESULT_TIME_END" = NEW."RESULT_TIME" where "ID" = "MDS_ROW"."ID";
+		end if;
+
+		if (OLD."RESULT_TIME" = "MDS_ROW"."RESULT_TIME_START")
+		then
+			update "MULTI_DATASTREAMS"
+				set "RESULT_TIME_START" = (select min("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "MDS_ROW"."ID")
+				where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+		end if;
+		if (OLD."RESULT_TIME" = "MDS_ROW"."RESULT_TIME_END")
+		then
+			update "MULTI_DATASTREAMS"
+				set "RESULT_TIME_END" = (select max("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."MULTI_DATASTREAM_ID" = "MDS_ROW"."ID")
+				where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+		end if;
+
+		return NEW;
+	end if;
 end if;
 
 
@@ -186,40 +276,80 @@ drop trigger if exists datastreams_actualization_delete ON "OBSERVATIONS";
 
 -- ---------------------------------------
 -- Function: datastreams_update_delete()
+--
+-- This function also updates multidatastreams. Updated fields are:
+-- PHENOMENON_TIME_START,PHENOMENON_TIME_END,RESULT_TIME_START,RESULT_TIME_END.
+-- Warning: OBSERVED_AREA not taken into account. 
 -- ---------------------------------------
 create or replace function datastreams_update_delete()
   returns trigger as
 $BODY$
 declare
 "DS_ROW" "DATASTREAMS"%rowtype;
+"MDS_ROW" "MULTI_DATASTREAMS"%rowtype;
 begin
 
-for "DS_ROW" in select * from "DATASTREAMS" where "ID"=OLD."DATASTREAM_ID"
-loop
-    if (OLD."PHENOMENON_TIME_START" = "DS_ROW"."PHENOMENON_TIME_START"
-        or coalesce(OLD."PHENOMENON_TIME_END", OLD."PHENOMENON_TIME_START") = "DS_ROW"."PHENOMENON_TIME_END")
-    then
-        update "DATASTREAMS"
-            set "PHENOMENON_TIME_START" = (select min("PHENOMENON_TIME_START") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
-            where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-        update "DATASTREAMS"
-            set "PHENOMENON_TIME_END" = (select max(coalesce("PHENOMENON_TIME_END", "PHENOMENON_TIME_START")) from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
-            where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-    end if;
+if (OLD."DATASTREAM_ID" is not null) 
+then
+	select * into "MDS_ROW" from "MULTI_DATASTREAMS" where "MULTI_DATASTREAMS"."ID"=OLD."MULTI_DATASTREAM_ID";
 
-    if (OLD."RESULT_TIME" = "DS_ROW"."RESULT_TIME_START")
-    then
-        update "DATASTREAMS"
-            set "RESULT_TIME_START" = (select min("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
-            where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-    end if;
-    if (OLD."RESULT_TIME" = "DS_ROW"."RESULT_TIME_END")
-    then
-        update "DATASTREAMS"
-            set "RESULT_TIME_END" = (select max("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
-            where "DATASTREAMS"."ID" = "DS_ROW"."ID";
-    end if;
-end loop;
+	if (OLD."PHENOMENON_TIME_START" = "DS_ROW"."PHENOMENON_TIME_START"
+		or coalesce(OLD."PHENOMENON_TIME_END", OLD."PHENOMENON_TIME_START") = "DS_ROW"."PHENOMENON_TIME_END")
+	then
+		update "DATASTREAMS"
+			set "PHENOMENON_TIME_START" = (select min("PHENOMENON_TIME_START") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
+			where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+		update "DATASTREAMS"
+			set "PHENOMENON_TIME_END" = (select max(coalesce("PHENOMENON_TIME_END", "PHENOMENON_TIME_START")) from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
+			where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+	end if;
+
+	if (OLD."RESULT_TIME" = "DS_ROW"."RESULT_TIME_START")
+	then
+		update "DATASTREAMS"
+			set "RESULT_TIME_START" = (select min("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
+			where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+	end if;
+	if (OLD."RESULT_TIME" = "DS_ROW"."RESULT_TIME_END")
+	then
+		update "DATASTREAMS"
+			set "RESULT_TIME_END" = (select max("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."DATASTREAM_ID" = "DS_ROW"."ID")
+			where "DATASTREAMS"."ID" = "DS_ROW"."ID";
+	end if;
+
+end if;	
+
+if (OLD."MULTI_DATASTREAM_ID" is not null) 
+then
+	select * into "MDS_ROW" from "MULTI_DATASTREAMS" where "MULTI_DATASTREAMS"."ID"=OLD."MULTI_DATASTREAM_ID";
+
+	if (OLD."PHENOMENON_TIME_START" = "DS_ROW"."PHENOMENON_TIME_START"
+		or coalesce(OLD."PHENOMENON_TIME_END", OLD."PHENOMENON_TIME_START") = "MDS_ROW"."PHENOMENON_TIME_END")
+	then
+		update "MULTI_DATASTREAMS"
+			set "PHENOMENON_TIME_START" = (select min("PHENOMENON_TIME_START") from "OBSERVATIONS" where "OBSERVATIONS"."MULTI_DATASTREAM_ID" = "MDS_ROW"."ID")
+			where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+		update "MULTI_DATASTREAMS"
+			set "PHENOMENON_TIME_END" = (select max(coalesce("PHENOMENON_TIME_END", "PHENOMENON_TIME_START")) from "OBSERVATIONS" where "OBSERVATIONS"."MULTI_DATASTREAM_ID" = "MDS_ROW"."ID")
+			where "DATASTREAMS"."ID" = "MDS_ROW"."ID";
+	end if;
+
+	if (OLD."RESULT_TIME" = "MDS_ROW"."RESULT_TIME_START")
+	then
+		update "MULTI_DATASTREAMS"
+			set "RESULT_TIME_START" = (select min("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."MULTI_DATASTREAM_ID" = "MDS_ROW"."ID")
+			where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+	end if;
+	if (OLD."RESULT_TIME" = "MDS_ROW"."RESULT_TIME_END")
+	then
+		update "MULTI_DATASTREAMS"
+			set "RESULT_TIME_END" = (select max("RESULT_TIME") from "OBSERVATIONS" where "OBSERVATIONS"."MULTI_DATASTREAM_ID" = "MDS_ROW"."ID")
+			where "MULTI_DATASTREAMS"."ID" = "MDS_ROW"."ID";
+	end if;
+
+end if;	
+
+
 return NULL;
 end
 $BODY$


### PR DESCRIPTION
Triggers updated Datastreams when Observations where added, modified or deleted, but MultiDatastreams weren't.
Added in the same triggers an IF section to do the same update on MultiDatastreams (the old code has been put into an IF section too).
note: in DELETE or UPDATE operation OBSERVED_AREA was not considered (I think for performance considerations) and are not considered in the MultiDatastream updating either.
In the update trigger there was a loop in the result of a query with a condition "equal" on the primary key of table DATASTREAMS, query that obviously can give only one result. I omitted the loop in the new DATASTREAM section, but didn't touch the Datastream one.