### PR TITLE
Running FROST as non-root in Docker

### DIFF
--- a/FROST-Server.HTTP/Dockerfile
+++ b/FROST-Server.HTTP/Dockerfile
@@ -1,7 +1,13 @@
 From tomcat:8.5-jdk11
 
-COPY target/docker_deps/ /usr/local/tomcat/lib/
+COPY target/docker_deps/ ${CATALINA_HOME}/lib/
 
 # Copy to images tomcat path
 ARG WAR_FILE
-COPY target/${WAR_FILE} /usr/local/tomcat/webapps/FROST-Server.war
+COPY target/${WAR_FILE} ${CATALINA_HOME}/webapps/FROST-Server.war
+
+RUN addgroup --system --gid 1000 tomcat \
+    && adduser --system --uid 1000 --gid 1000 tomcat \
+    && chown -R tomcat $CATALINA_HOME
+
+USER tomcat

--- a/FROST-Server.MQTTP/Dockerfile
+++ b/FROST-Server.MQTTP/Dockerfile
@@ -1,7 +1,13 @@
 From tomcat:8.5-jdk11
 
-COPY target/docker_deps/ /usr/local/tomcat/lib/
+COPY target/docker_deps/ ${CATALINA_HOME}/lib/
 
 # Copy to images tomcat path
 ARG WAR_FILE
-COPY target/${WAR_FILE} /usr/local/tomcat/webapps/FROST-Server.war
+COPY target/${WAR_FILE} ${CATALINA_HOME}/webapps/FROST-Server.war
+
+RUN addgroup --system --gid 1000 tomcat \
+    && adduser --system --uid 1000 --gid 1000 tomcat \
+    && chown -R tomcat $CATALINA_HOME
+
+USER tomcat


### PR DESCRIPTION
It's widley considered best practice to not let docker containers run with root priviliges. And while the official Tomcat-Image maintainers seem to be of a different opinion (https://github.com/docker-library/tomcat/issues/14) this should not stop other projects from fixing this flaw.

As we want to use the FROST-Server in an Openshift-Cluster, it is vital to not be using the root user, as OS by default restricts this behaviour.

With this PR both Dockerfiles of the HTTP and MQTTP variant of FROST are extended by creating a new "tomcat"-User with the belonging group. This user then gets access rights to `CATALINA_HOME` and finally we switch to the user so that the container is running as non-root.