### PR TITLE
Fix folder permissions in docker for openshift deployment

### DIFF
--- a/FROST-Server.HTTP/Dockerfile
+++ b/FROST-Server.HTTP/Dockerfile
@@ -7,7 +7,10 @@ ARG WAR_FILE
 COPY target/${WAR_FILE} ${CATALINA_HOME}/webapps/FROST-Server.war
 
 RUN addgroup --system --gid 1000 tomcat \
-    && adduser --system --uid 1000 --gid 1000 tomcat \
-    && chown -R tomcat $CATALINA_HOME
+    && adduser --system --uid 1000 --gid 1000 tomcat
+
+# Fix Folder permissions for Openshift-Deployment (according to https://docs.openshift.com/container-platform/4.4/openshift_images/create-images.html#use-uid_create-images)
+RUN chgrp -R 0 $CATALINA_HOME && \
+    chmod -R g=u $CATALINA_HOME
 
 USER tomcat

--- a/FROST-Server.MQTTP/Dockerfile
+++ b/FROST-Server.MQTTP/Dockerfile
@@ -7,7 +7,10 @@ ARG WAR_FILE
 COPY target/${WAR_FILE} ${CATALINA_HOME}/webapps/FROST-Server.war
 
 RUN addgroup --system --gid 1000 tomcat \
-    && adduser --system --uid 1000 --gid 1000 tomcat \
-    && chown -R tomcat $CATALINA_HOME
+    && adduser --system --uid 1000 --gid 1000 tomcat
+
+# Fix Folder permissions for Openshift-Deployment (according to https://docs.openshift.com/container-platform/4.4/openshift_images/create-images.html#use-uid_create-images)
+RUN chgrp -R 0 $CATALINA_HOME && \
+    chmod -R g=u $CATALINA_HOME
 
 USER tomcat


### PR DESCRIPTION
Hey, it's me again :)

While the previous PR https://github.com/FraunhoferIOSB/FROST-Server/pull/237 made the docker images more secure it wasn't enough to make the official FROST-Images be run in an Openshift environment.

After consulting the official guidelines to [creating images for openshift](https://docs.openshift.com/container-platform/4.4/openshift_images/create-images.html#use-uid_create-images) the following problem surfaced:

> By default, OpenShift Container Platform runs containers using an arbitrarily assigned user ID. This provides additional security against processes escaping the container due to a container engine vulnerability and thereby achieving escalated permissions on the host node.

To adress this issue the recommended code was added to the Dockerfiles of the HTTP and MQTTP variants.

This time I went a step further and used https://github.com/minishift/minishift to test the changes in this PR successfully.