### PR TITLE
Cleaned up obsolete settings, renamed experimental to extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,13 @@ It mainly affects installations without an enabled ingress resource.
 * Added a resultFormat=GeoJSON, as described in: [GeoJSON-ResultFormat.md](https://fraunhoferiosb.github.io/FROST-Server/extensions/GeoJSON-ResultFormat.md).
 * Added a custom entity linking extension, as described in: [EntityLinking.md](https://github.com/INSIDE-information-systems/SensorThingsAPI/blob/master/EntityLinking/Linking.md).
 * The safe_cast_to_ functions in PostgreSQL are now IMMUTABLE so they can be used in indices.
+* Converted JSON-holding columns to JsonB.
+  **Caution**: On large databases this conversion can take considerable time, during
+  which the table being converted is locked.
 
 **Internal changes & Bugfixes**
 * The JSON writer component is now about 5 times as fast.
+* Fixed PostgreSQL triggers not running for MultiDatastreams.
 
 
 ## Release Version 1.11.0

--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/parser/query/QueryParser.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/parser/query/QueryParser.java
@@ -60,7 +60,7 @@ public class QueryParser extends AbstractParserVisitor {
     public QueryParser(CoreSettings settings, ResourcePath path) {
         this.settings = settings;
         this.path = path;
-        customLinksEnabled = settings.getExperimentalSettings().getBoolean(CoreSettings.TAG_ENABLE_CUSTOM_LINKS, CoreSettings.class);
+        customLinksEnabled = settings.getExtensionSettings().getBoolean(CoreSettings.TAG_CUSTOM_LINKS_ENABLE, CoreSettings.class);
     }
 
     public static Query parseQuery(String query, CoreSettings settings, ResourcePath path) {

--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/service/Service.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/service/Service.java
@@ -283,8 +283,7 @@ public class Service implements AutoCloseable {
             return errorResponse(response, 500, ex.getMessage());
         }
 
-        boolean exposeFeatures = settings.getExperimentalSettings().getBoolean(CoreSettings.TAG_EXPOSE_SERVICE_SETTINGS, settings.getClass());
-        if (request.getVersion() == Version.V_1_1 || exposeFeatures) {
+        if (request.getVersion() == Version.V_1_1) {
             Map<String, Object> serverSettings = new LinkedHashMap<>();
             result.put(KEY_SERVER_SETTINGS, serverSettings);
 

--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/settings/CoreSettings.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/settings/CoreSettings.java
@@ -112,9 +112,7 @@ public class CoreSettings implements ConfigDefaults {
 
     // Experimental settings
     @DefaultValueBoolean(false)
-    public static final String TAG_EXPOSE_SERVICE_SETTINGS = "exposeServerSettings";
-    @DefaultValueBoolean(false)
-    public static final String TAG_ENABLE_CUSTOM_LINKS = "customLinks.enable";
+    public static final String TAG_CUSTOM_LINKS_ENABLE = "customLinks.enable";
     @DefaultValueInt(0)
     public static final String TAG_CUSTOM_LINKS_RECURSE_DEPTH = "customLinks.recurseDepth";
 
@@ -125,7 +123,7 @@ public class CoreSettings implements ConfigDefaults {
     public static final String PREFIX_MQTT = "mqtt.";
     public static final String PREFIX_HTTP = "http.";
     public static final String PREFIX_AUTH = "auth.";
-    public static final String PREFIX_EXPERIMENTAL = "experimental.";
+    public static final String PREFIX_EXTENSION = "extension.";
     public static final String PREFIX_PERSISTENCE = "persistence.";
     public static final String PREFIX_PLUGINS = "plugins.";
 
@@ -185,9 +183,9 @@ public class CoreSettings implements ConfigDefaults {
      */
     private Settings pluginSettings;
     /**
-     * The Experimental settings.
+     * The settings of various non-standard extensions that are not plugins.
      */
-    private Settings experimentalSettings;
+    private Settings extensionSettings;
 
     /**
      * The extensions, or other code parts that require Liquibase.
@@ -260,7 +258,7 @@ public class CoreSettings implements ConfigDefaults {
         httpSettings = new Settings(settings.getProperties(), PREFIX_HTTP, false);
         authSettings = new Settings(settings.getProperties(), PREFIX_AUTH, false);
         pluginSettings = new CachedSettings(settings.getProperties(), PREFIX_PLUGINS, false);
-        experimentalSettings = new CachedSettings(settings.getProperties(), PREFIX_EXPERIMENTAL, false);
+        extensionSettings = new CachedSettings(settings.getProperties(), PREFIX_EXTENSION, false);
     }
 
     private void initExtensions() {
@@ -271,7 +269,7 @@ public class CoreSettings implements ConfigDefaults {
         if (isEnableActuation()) {
             enabledExtensions.add(Extension.ACTUATION);
         }
-        if (getExperimentalSettings().getBoolean(CoreSettings.TAG_ENABLE_CUSTOM_LINKS, CoreSettings.class)) {
+        if (getExtensionSettings().getBoolean(CoreSettings.TAG_CUSTOM_LINKS_ENABLE, CoreSettings.class)) {
             enabledExtensions.add(Extension.ENTITY_LINKING);
         }
     }
@@ -316,8 +314,8 @@ public class CoreSettings implements ConfigDefaults {
         return busSettings;
     }
 
-    public Settings getExperimentalSettings() {
-        return experimentalSettings;
+    public Settings getExtensionSettings() {
+        return extensionSettings;
     }
 
     public Settings getHttpSettings() {

--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/util/CustomLinksHelper.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/util/CustomLinksHelper.java
@@ -72,8 +72,8 @@ public class CustomLinksHelper {
     }
 
     public static void expandCustomLinks(CoreSettings settings, Entity<?> e, ResourcePath path) {
-        final Settings experimentalSettings = settings.getExperimentalSettings();
-        if (experimentalSettings.getBoolean(CoreSettings.TAG_ENABLE_CUSTOM_LINKS, CoreSettings.class)) {
+        final Settings experimentalSettings = settings.getExtensionSettings();
+        if (experimentalSettings.getBoolean(CoreSettings.TAG_CUSTOM_LINKS_ENABLE, CoreSettings.class)) {
             int recurseDepth = experimentalSettings.getInt(CoreSettings.TAG_CUSTOM_LINKS_RECURSE_DEPTH, CoreSettings.class);
             if (e instanceof NamedEntity) {
                 CustomLinksHelper.expandCustomLinks(((NamedEntity) e).getProperties(), path, recurseDepth);
@@ -111,8 +111,8 @@ public class CustomLinksHelper {
     }
 
     public static void cleanPropertiesMap(CoreSettings settings, Entity<?> entity) {
-        final Settings experimentalSettings = settings.getExperimentalSettings();
-        if (!experimentalSettings.getBoolean(CoreSettings.TAG_ENABLE_CUSTOM_LINKS, CoreSettings.class)) {
+        final Settings experimentalSettings = settings.getExtensionSettings();
+        if (!experimentalSettings.getBoolean(CoreSettings.TAG_CUSTOM_LINKS_ENABLE, CoreSettings.class)) {
             return;
         }
         int recurseDepth = experimentalSettings.getInt(CoreSettings.TAG_CUSTOM_LINKS_RECURSE_DEPTH, CoreSettings.class);

--- a/FROST-Server.Core/src/test/java/de/fraunhofer/iosb/ilt/frostserver/parser/QueryParserTest.java
+++ b/FROST-Server.Core/src/test/java/de/fraunhofer/iosb/ilt/frostserver/parser/QueryParserTest.java
@@ -517,8 +517,8 @@ public class QueryParserTest {
 
     @Test
     public void testExpandCustom() {
-        boolean old = settings.getExperimentalSettings().getBoolean(CoreSettings.TAG_ENABLE_CUSTOM_LINKS, CoreSettings.class);
-        settings.getExperimentalSettings().set(CoreSettings.TAG_ENABLE_CUSTOM_LINKS, true);
+        boolean old = settings.getExtensionSettings().getBoolean(CoreSettings.TAG_CUSTOM_LINKS_ENABLE, CoreSettings.class);
+        settings.getExtensionSettings().set(CoreSettings.TAG_CUSTOM_LINKS_ENABLE, true);
 
         String query = "$expand=properties/sub/link.Thing";
         Query expResult = new Query(settings.getQueryDefaults(), path)
@@ -532,8 +532,8 @@ public class QueryParserTest {
         Query result = QueryParser.parseQuery(query, settings, path);
         Assert.assertEquals(expResult, result);
 
-        settings.getExperimentalSettings().set(CoreSettings.TAG_ENABLE_CUSTOM_LINKS, old);
-        Assert.assertEquals(old, settings.getExperimentalSettings().getBoolean(CoreSettings.TAG_ENABLE_CUSTOM_LINKS, CoreSettings.class));
+        settings.getExtensionSettings().set(CoreSettings.TAG_CUSTOM_LINKS_ENABLE, old);
+        Assert.assertEquals(old, settings.getExtensionSettings().getBoolean(CoreSettings.TAG_CUSTOM_LINKS_ENABLE, CoreSettings.class));
     }
 
     @Test

--- a/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/PgExpressionHandler.java
+++ b/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/PgExpressionHandler.java
@@ -159,8 +159,8 @@ public class PgExpressionHandler<J extends Comparable> implements ExpressionVisi
     public PgExpressionHandler(CoreSettings settings, QueryBuilder<J> queryBuilder, TableRef<J> tableRef) {
         this.queryBuilder = queryBuilder;
         this.tableRef = tableRef;
-        final Settings experimentalSettings = settings.getExperimentalSettings();
-        if (experimentalSettings.getBoolean(CoreSettings.TAG_ENABLE_CUSTOM_LINKS, CoreSettings.class)) {
+        final Settings experimentalSettings = settings.getExtensionSettings();
+        if (experimentalSettings.getBoolean(CoreSettings.TAG_CUSTOM_LINKS_ENABLE, CoreSettings.class)) {
             maxCustomLinkDepth = experimentalSettings.getInt(CoreSettings.TAG_CUSTOM_LINKS_RECURSE_DEPTH, CoreSettings.class);
         }
     }

--- a/FROST-Server.Tests/src/test/java/de/fraunhofer/iosb/ilt/statests/f02customlinks/CustomLinksTests.java
+++ b/FROST-Server.Tests/src/test/java/de/fraunhofer/iosb/ilt/statests/f02customlinks/CustomLinksTests.java
@@ -20,6 +20,7 @@ package de.fraunhofer.iosb.ilt.statests.f02customlinks;
 import de.fraunhofer.iosb.ilt.frostserver.model.EntityType;
 import de.fraunhofer.iosb.ilt.frostserver.path.UrlHelper;
 import de.fraunhofer.iosb.ilt.frostserver.path.Version;
+import de.fraunhofer.iosb.ilt.frostserver.settings.CoreSettings;
 import de.fraunhofer.iosb.ilt.sta.ServiceFailureException;
 import de.fraunhofer.iosb.ilt.sta.model.Datastream;
 import de.fraunhofer.iosb.ilt.sta.model.FeatureOfInterest;
@@ -65,7 +66,7 @@ public class CustomLinksTests extends AbstractTestClass {
     private static final Properties SERVER_PROPERTIES = new Properties();
 
     static {
-        SERVER_PROPERTIES.put("experimental.customLinks.enable", "true");
+        SERVER_PROPERTIES.put(CoreSettings.PREFIX_EXTENSION + CoreSettings.TAG_CUSTOM_LINKS_ENABLE, "true");
     }
 
     public CustomLinksTests(ServerVersion version) {

--- a/docs/settings/plugins.md
+++ b/docs/settings/plugins.md
@@ -31,7 +31,7 @@ The BatchProcessing plugin implements the Batch Requests extension as described
 in the SensorThings API standard.
 
 * **plugins.batchProcessing.enable:**  
-  Toggle indicating BatchProcessing should be enabled. Defaults: `true`.
+  Toggle indicating BatchProcessing should be enabled. Default: `true`.
 
 
 ### DataArray
@@ -40,7 +40,7 @@ The DataArray plugin implements the SensorThings Data Array Extension as describ
 in the SensorThings API standard.
 
 * **plugins.dataArray.enable:**  
-  Toggle indicating the ResultFormat dataArray should be enabled. Defaults: `true`.
+  Toggle indicating the ResultFormat dataArray should be enabled. Default: `true`.
 
 
 ### CSV Result Format
@@ -49,7 +49,7 @@ The CSV plugin implements a CSV result formatter, enabling CSV output as describ
 in: [CSV-ResultFormat](https://github.com/INSIDE-information-systems/SensorThingsAPI/blob/master/CSV-ResultFormat/CSV-ResultFormat.md)
 
 * **plugins.csv.enable:**  
-  Toggle indicating the ResultFormat CSV should be enabled. Defaults: `true`.
+  Toggle indicating the ResultFormat CSV should be enabled. Default: `true`.
 
 
 ### OpenAPI
@@ -60,4 +60,4 @@ This description is still experimental, and probably incomplete.
 If you use it and have experience with OpenAPI, we welcome feedback!
 
 * **plugins.openApi.enable:**  
-  Toggle indicating the OpenAPI plugin should be enabled. Defaults: `false`.
+  Toggle indicating the OpenAPI plugin should be enabled. Default: `false`.

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -47,10 +47,10 @@ These are settings affecting both the MQTT and HTTP packages.
   If true, navigationLinks are absolute, otherwise relative.
 * **enableActuation:**  
   If false, actuation entities are hidden from the index page, and navigation links to the actuation entities are
-  not shown. The entities can be accessed regardless of the setting. Defaults: `false`.
+  not shown. The entities can be accessed regardless of the setting. Default: `false`.
 * **enableMultiDatastream:**  
   If false, MultiDatastream entities are hidden from the index page, and navigation links to the MultiDatastream entities are
-  not shown. The entities can be accessed regardless of the setting. Defaults: `true`.
+  not shown. The entities can be accessed regardless of the setting. Default: `true`.
 
 
 ## HTTP settings
@@ -58,15 +58,15 @@ These are settings affecting both the MQTT and HTTP packages.
 These are settings for the HTTP package.
 
 * **http.cors.enable:**  
-  If true, a filter is added to allow cross-site-scripting. Defaults: `false`.
+  If true, a filter is added to allow cross-site-scripting. Default: `false`.
 * **http.cors.allowed.origins:**  
   A list of origins that are allowed to access the resource. A * can be specified to enable access to resource
   from any origin. Otherwise, a whitelist of comma separated origins can be provided. Eg: `http://www.w3.org, https://www.apache.org`.
-  Defaults: `*`.
+  Default: `*`.
 * **http.cors.allowed.methods:**  
   A comma separated list of HTTP methods that can be used to access the resource, using cross-origin requests.
   These are the methods which will also be included as part of Access-Control-Allow-Methods header in pre-flight response.
-  Eg: `GET, POST`. Defaults: `GET, HEAD, OPTIONS`.
+  Eg: `GET, POST`. Default: `GET, HEAD, OPTIONS`.
 * **http.cors.exposed.headers:**  
   A comma separated list of headers other than simple response headers that browsers are allowed to access.
   These are the headers which will also be included as part of Access-Control-Expose-Headers header in the pre-flight response.
@@ -74,17 +74,17 @@ These are settings for the HTTP package.
 * **http.cors.allowed.headers:**  
   A comma separated list of request headers that can be used when making an actual request. These headers will
   also be returned as part of Access-Control-Allow-Headers header in a pre-flight response. Eg: `Origin,Accept`.
-  Defaults: `Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers, Authorization`.
+  Default: `Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers, Authorization`.
 * **http.cors.support.credentials:**  
   A flag that indicates whether the resource supports user credentials. This flag is exposed as part of
   Access-Control-Allow-Credentials header in a pre-flight response. It helps browser determine whether or not an actual request can
-  be made using credentials. Defaults: `false`.
+  be made using credentials. Default: `false`.
 * **http.cors.preflight.maxage:**  
   The amount of seconds, browser is allowed to cache the result of the pre-flight request. This will be included
   as part of Access-Control-Max-Age header in the pre-flight response. A negative value will prevent CORS Filter from adding this
-  response header to pre-flight response. Defaults: `1800`.
+  response header to pre-flight response. Default: `1800`.
 * **http.cors.request.decorate:**  
-  A flag to control if CORS specific attributes should be added to HttpServletRequest object or not. Defaults: `true`.
+  A flag to control if CORS specific attributes should be added to HttpServletRequest object or not. Default: `true`.
 
 
 ## Auth settings
@@ -231,17 +231,15 @@ These settings configure the way the HTTP and MQTT packages communicate with eac
     The maximum number of "in-flight" messages to allow on the MQTT bus.
 
 
-## Experimental Settings
+## Extension Settings
 
-These settings control non-standard, experimental behaviour.
+These settings control various non-standard extensions.
 
-* **experimental.exposeServerSettings:**  
-  Adds a serverSettings element to the v1.0 index page, as discussed on the SensorThings API
-  GitHub page in [issue 4](https://github.com/opengeospatial/sensorthings/issues/4).
-  You should probably use v1.1 instead.
-* **experimental.customLinks.enable:**  
-  Enables the EntityLinking extension described in: [https://github.com/INSIDE-information-systems/SensorThingsAPI/blob/master/EntityLinking/Linking.md](https://github.com/INSIDE-information-systems/SensorThingsAPI/blob/master/EntityLinking/Linking.md)
-* **experimental.customLinks.recurseDepth:**  
+* **extension.customLinks.enable:**  
+  Enables the EntityLinking extension described in:
+  [https://github.com/INSIDE-information-systems/SensorThingsAPI/blob/master/EntityLinking/Linking.md](https://github.com/INSIDE-information-systems/SensorThingsAPI/blob/master/EntityLinking/Linking.md)
+   Default: `false`.
+* **extension.customLinks.recurseDepth:**  
   The depth to search for custom links in properties. Default: 0 (only top level)
 
 


### PR DESCRIPTION
This renames all `experimental.*` settings to `extension.*`
This removes the `experimental.exposeServerSettings` setting