### PR TITLE
Change default request encoding to utf-8

### DIFF
--- a/FROST-Server.HTTP.Common/src/main/java/de/fraunhofer/iosb/ilt/frostserver/http/common/ServletV1P0.java
+++ b/FROST-Server.HTTP.Common/src/main/java/de/fraunhofer/iosb/ilt/frostserver/http/common/ServletV1P0.java
@@ -127,6 +127,9 @@ public class ServletV1P0 extends HttpServlet {
     }
 
     private ServiceRequest serviceRequestFromHttpRequest(HttpServletRequest request, String requestType) throws IOException {
+        if(request.getCharacterEncoding() == null) {
+            request.setCharacterEncoding("UTF-8");
+        }
         // request.getPathInfo() is decoded, breaking urls that contain //
         // (ids that are urls)
         String requestURI = request.getRequestURI();


### PR DESCRIPTION
As discussed in #291, `ISO-8859-1` encoding is at least unusual for json payloads.
This commit therefore changes the default request encoding to `utf-8` if not otherwise specified by the client.
Also see https://cwiki.apache.org/confluence/display/TOMCAT/Character+Encoding#CharacterEncoding-Q3 for details.