### PR TITLE
Change DatabaseHandler init log from error to info

### DIFF
--- a/FROST-Server.Auth.Basic/src/main/java/de/fraunhofer/iosb/ilt/frostserver/auth/basic/DatabaseHandler.java
+++ b/FROST-Server.Auth.Basic/src/main/java/de/fraunhofer/iosb/ilt/frostserver/auth/basic/DatabaseHandler.java
@@ -64,7 +64,7 @@ public class DatabaseHandler {
 
     private static synchronized void createInstance(CoreSettings coreSettings) {
         if (instance == null) {
-            LOGGER.error("Initialising DatabaseHandler.");
+            LOGGER.info("Initialising DatabaseHandler.");
             instance = new DatabaseHandler(coreSettings);
         }
     }


### PR DESCRIPTION
Initialising DatabaseHandler is not an error, but part of normal startup.