### PR TITLE
Set PostgreSQL role to enable Row-Level Security

### DIFF
--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/PersistenceManager.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/PersistenceManager.java
@@ -29,6 +29,7 @@ import de.fraunhofer.iosb.ilt.frostserver.query.Query;
 import de.fraunhofer.iosb.ilt.frostserver.settings.CoreSettings;
 import de.fraunhofer.iosb.ilt.frostserver.util.exception.IncompleteEntityException;
 import de.fraunhofer.iosb.ilt.frostserver.util.exception.NoSuchEntityException;
+import java.security.Principal;
 import java.util.List;
 
 /**
@@ -121,6 +122,8 @@ public interface PersistenceManager extends AutoCloseable {
      * @return The settings that were used to initialise this PM.
      */
     public CoreSettings getCoreSettings();
+
+    public void setRole(Principal user);
 
     public void commit();
 

--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/service/Service.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/service/Service.java
@@ -61,6 +61,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -148,6 +149,9 @@ public class Service implements AutoCloseable {
      * @return the service response passed, or a new one.
      */
     public ServiceResponse execute(ServiceRequest request, ServiceResponse response) {
+        if (!transactionActive) {
+            getPm().setRole(request.getUserPrincipal());
+        }
         if (response == null) {
             response = new ServiceResponseDefault();
         }
@@ -189,7 +193,8 @@ public class Service implements AutoCloseable {
      *
      * @return this
      */
-    public Service startTransaction() {
+    public Service startTransaction(Principal user) {
+        getPm().setRole(user);
         transactionActive = true;
         return this;
     }

--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/settings/PersistenceSettings.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/settings/PersistenceSettings.java
@@ -65,6 +65,8 @@ public class PersistenceSettings implements ConfigDefaults {
     public static final String TAG_COUNT_MODE = "countMode";
     @DefaultValueInt(10_000)
     public static final String TAG_ESTIMATE_COUNT_THRESHOLD = "countEstimateThreshold";
+    @DefaultValueBoolean(false)
+    public static final String TAG_TRANSACTION_ROLE = "transactionRole";
 
     /**
      * Fully-qualified class name of the PersistenceManager implementation class
@@ -91,6 +93,10 @@ public class PersistenceSettings implements ConfigDefaults {
      */
     private boolean timeoutQueries;
     /**
+     * Flag indicating role should be set in transaction from HTTP user, typically for Row-Level Security.
+     */
+    private boolean transactionRole;
+    /**
      * Extension point for implementation specific settings
      */
     private Settings customSettings;
@@ -112,6 +118,7 @@ public class PersistenceSettings implements ConfigDefaults {
         timeoutQueries = queryTimeout > 0;
         countMode = CountMode.fromValue(settings.get(TAG_COUNT_MODE, getClass()));
         estimateCountThreshold = settings.getInt(TAG_ESTIMATE_COUNT_THRESHOLD, getClass());
+        transactionRole = settings.getBoolean(TAG_TRANSACTION_ROLE, getClass());
         customSettings = settings;
     }
 
@@ -129,6 +136,10 @@ public class PersistenceSettings implements ConfigDefaults {
 
     public String getIdGenerationMode() {
         return idGenerationMode;
+    }
+
+    public boolean isTransactionRole() {
+        return transactionRole;
     }
 
     /**

--- a/FROST-Server.Core/src/test/java/de/fraunhofer/iosb/ilt/frostserver/mqtt/MqttManagerTest.java
+++ b/FROST-Server.Core/src/test/java/de/fraunhofer/iosb/ilt/frostserver/mqtt/MqttManagerTest.java
@@ -42,6 +42,7 @@ import de.fraunhofer.iosb.ilt.frostserver.util.Constants;
 import de.fraunhofer.iosb.ilt.frostserver.util.TestModel;
 import de.fraunhofer.iosb.ilt.frostserver.util.exception.IncompleteEntityException;
 import de.fraunhofer.iosb.ilt.frostserver.util.exception.NoSuchEntityException;
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -350,6 +351,10 @@ class MqttManagerTest {
         @Override
         public CoreSettings getCoreSettings() {
             return coreSettings;
+        }
+
+        @Override
+        public void setRole(Principal user) {
         }
 
         @Override

--- a/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/PostgresPersistenceManager.java
+++ b/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/PostgresPersistenceManager.java
@@ -61,6 +61,7 @@ import de.fraunhofer.iosb.ilt.frostserver.util.exception.NoSuchEntityException;
 import de.fraunhofer.iosb.ilt.frostserver.util.exception.UpgradeFailedException;
 import java.io.IOException;
 import java.io.Writer;
+import java.security.Principal;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.text.ParseException;
@@ -381,6 +382,14 @@ public class PostgresPersistenceManager extends AbstractPersistenceManager imple
 
         long rowCount = sqlDelete.execute();
         LOGGER.debug("Deleted {} rows using query {}", rowCount, sqlDelete);
+    }
+
+    @Override
+    public void setRole(Principal user) {
+        if (settings.getPersistenceSettings().isTransactionRole()) {
+            getDslContext().setLocal(
+                DSL.name("ROLE"), DSL.val(user == null ? "anonymous" : user.getName()));
+        }
     }
 
     @Override

--- a/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/PostgresPersistenceManager.java
+++ b/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/PostgresPersistenceManager.java
@@ -387,8 +387,9 @@ public class PostgresPersistenceManager extends AbstractPersistenceManager imple
     @Override
     public void setRole(Principal user) {
         if (settings.getPersistenceSettings().isTransactionRole()) {
-            getDslContext().setLocal(
-                DSL.name("ROLE"), DSL.val(user == null ? "anonymous" : user.getName()));
+            getDslContext()
+                .setLocal(DSL.name("ROLE"), DSL.val(user == null ? "anonymous" : user.getName()))
+                .execute();
         }
     }
 

--- a/Plugins/BatchProcessing/src/main/java/de/fraunhofer/iosb/ilt/frostserver/plugin/batchprocessing/BatchProcessor.java
+++ b/Plugins/BatchProcessing/src/main/java/de/fraunhofer/iosb/ilt/frostserver/plugin/batchprocessing/BatchProcessor.java
@@ -126,7 +126,7 @@ public class BatchProcessor<C extends Content> {
             content.setStatus(400, "Bad Request");
             return content;
         }
-        service.startTransaction();
+        service.startTransaction(batchRequest.getUserPrincipal());
         Batch response = batchFactory.createBatch(batchRequest.getVersion(), service.getSettings(), true);
         List<Part> parts = changeset.getParts();
         List<ContentIdPair> contentIds = new ArrayList<>(parts.size());

--- a/docs/settings/auth.md
+++ b/docs/settings/auth.md
@@ -17,6 +17,9 @@ persistence backends. The interface to be implemented is de.fraunhofer.iosb.ilt.
 An example docker-compose file with basic auth set up can be found at: 
 [docker-compose-separated-basicauth.yaml](https://github.com/FraunhoferIOSB/FROST-Server/blob/v2.x/scripts/docker-compose-separated-basicauth.yaml)
 
+More fine-grained authorisation rules can be configured using:
+* plugins with `EntityType` validators,
+* PostgreSQL Row-level security (see `persistence.transactionRole` setting).
 
 ## Roles
 

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -170,6 +170,10 @@ database persistence manager, one using QueryDSL, and one using JOOQ.
     Both, server and client generated ids, are allowed.
   * **`ClientGeneratedOnly`:**  
     Client has to provide @iot.id to create entities.
+* **persistence.transactionRole:**
+  If true, [SET LOCAL ROLE](https://www.postgresql.org/docs/current/sql-set-role.html)
+  is used for each query and set as HTTP user name or `anonymous` for anonymous HTTP users,
+  to be used typically with [Row-Level Security](https://www.postgresql.org/docs/current/ddl-rowsecurity.html). Default: `false`.
 * **persistence.db.jndi.datasource:**  
   JNDI data source name, used when running in Tomcat/Wildfly.
 * **persistence.db.driver:**  

--- a/docs/settings/settings.md
+++ b/docs/settings/settings.md
@@ -173,7 +173,9 @@ database persistence manager, one using QueryDSL, and one using JOOQ.
 * **persistence.transactionRole:**
   If true, [SET LOCAL ROLE](https://www.postgresql.org/docs/current/sql-set-role.html)
   is used for each query and set as HTTP user name or `anonymous` for anonymous HTTP users,
-  to be used typically with [Row-Level Security](https://www.postgresql.org/docs/current/ddl-rowsecurity.html). Default: `false`.
+  to be used typically with [Row-Level Security](https://www.postgresql.org/docs/current/ddl-rowsecurity.html).
+  The PostgreSQL role is not related to the AuthProvider roles security (auth.role.* settings) which is also applied.
+  Default: `false`.
 * **persistence.db.jndi.datasource:**  
   JNDI data source name, used when running in Tomcat/Wildfly.
 * **persistence.db.driver:**  


### PR DESCRIPTION
This is a possible solution to implement Entity-based security (#111).
Is the documentation enough to understand what the feature does? The `transactionRole` setting naming could surely be improved.
Should it provide some kind of sample for a RLS setup? I don't think that providing a full RLS config should be part of this PR.

As for #1299 PR, I don't have much time to add tests.