### PR TITLE
Fix ClusterIP typo in mqtt kubernetes service

### DIFF
--- a/helm/frost-server/templates/mqtt-service.yaml
+++ b/helm/frost-server/templates/mqtt-service.yaml
@@ -44,8 +44,8 @@ spec:
       port: {{ .Values.frost.mqtt.ports.websocket.servicePort }}
       targetPort: websocket
   {{- end }}
-  {{- if eq .Values.frost.mqtt.serviceType "ClusterIp" }}
-  type: ClusterIp
+  {{- if eq .Values.frost.mqtt.serviceType "ClusterIP" }}
+  type: ClusterIP
   ports:
     - name: mqtt
       port: {{ .Values.frost.mqtt.ports.mqtt.servicePort }}


### PR DESCRIPTION
I was not able to use a ClusterIP for the mqtt service, because there was a typo.
Kubernetes reported:
`
one or more objects failed to apply, reason: Service "frost-server-frost-server-mqtt" is invalid: spec.type: Unsupported value: "ClusterIp": supported values: "ClusterIP", "ExternalName", "LoadBalancer", "NodePort".
`