### PR TITLE
Update class name of referenced MQTT-Server implementation  in Config-file.

### DIFF
--- a/FROST-Server.MQTT/src/main/resources/FrostMqtt.properties
+++ b/FROST-Server.MQTT/src/main/resources/FrostMqtt.properties
@@ -2,7 +2,7 @@
 serviceRootUrl=http://localhost:8080/FROST-Server
 
 # MQTT settings
-mqtt.mqttServerImplementationClass=de.fraunhofer.iosb.ilt.sensorthingsserver.mqtt.moquette.MoquetteMqttServer
+mqtt.mqttServerImplementationClass=de.fraunhofer.iosb.ilt.frostserver.mqtt.moquette.MoquetteMqttServer
 mqtt.Enabled=true
 mqtt.Port=1883
 mqtt.QoS=1


### PR DESCRIPTION
FrostMqtt.properties still referenced the sensorthings-named package for the MQTT-Server Implementation.

