### PR TITLE
feat: use toYaml for extra environment variables as in ingress annota…

### DIFF
--- a/helm/frost-server/templates/http-deployment.yaml
+++ b/helm/frost-server/templates/http-deployment.yaml
@@ -392,5 +392,5 @@ spec:
 
             # Extra Environment Variables
             {{- if .Values.frost.http.extraEnv }}
-                {{- .Values.frost.http.extraEnv | nindent 12 }}
+                {{- toYaml .Values.frost.http.extraEnv | nindent 12 }}
             {{- end }}

--- a/helm/frost-server/templates/mqtt-deployment.yaml
+++ b/helm/frost-server/templates/mqtt-deployment.yaml
@@ -397,7 +397,7 @@ spec:
 
             # Extra Environment Variables
             {{- if .Values.frost.mqtt.extraEnv }}
-                {{- .Values.frost.mqtt.extraEnv | nindent 12 }}
+                {{- toYaml .Values.frost.mqtt.extraEnv | nindent 12 }}
             {{- end }}
 
 {{- end -}}


### PR DESCRIPTION
In 
- `helm/frost-server/templates/http-ingress.yaml`
- `helm/frost-server/templates/mqtt-ingress.yaml`
for the adding the annotations through values `toYaml` is used, but for adding extraEnv in
- `helm/frost-server/templates/http-deployment.yaml`
- `helm/frost-server/templates/mqtt-deployment.yaml`
`toYaml` is NOT used.

This PR adds `toYaml` to the http and mqtt deployments for extraEnv for a unique configuration.