### PR TITLE
Use external db for basic-auth if specified

### DIFF
--- a/helm/frost-server/templates/http-deployment.yaml
+++ b/helm/frost-server/templates/http-deployment.yaml
@@ -291,8 +291,13 @@ spec:
               value: ""
             - name: auth_db_driver
               value: "{{ .Values.frost.db.driver }}"
+            {{ if .Values.frost.db.enableIntegratedDb }}
             - name: auth_db_url
               value: {{ printf "jdbc:postgresql://%s:5432/%s" (include "frost-server.fullName" (merge (dict "tier" "db") .)) .Values.frost.db.database | quote }}
+            {{ else }}
+            - name: auth_db_url
+              value: "{{ .Values.frost.db.dbExternalConnectionString }}"
+            {{ end }}
             - name: auth_autoUpdateDatabase
               value: "{{tpl .Values.frost.auth.db.autoUpdate . }}"
             - name: auth_db_conn_max


### PR DESCRIPTION
If an external database connection string is specified in the Helm deployment the Basic Auth module won't use the specified string and instead look for the service of the integrated database. This renders the Basic Auth functionality useless if one opts out of using the integrated database, because you can't customize the auth db connection string in any other way. 

This PR fixes this issue by using the `frost.db.dbExternalConnectionString` if defined.
