### PR TITLE
Removes 'version' from docker YAML files

### DIFF
--- a/scripts/docker-compose-separated-basicauth.yaml
+++ b/scripts/docker-compose-separated-basicauth.yaml
@@ -1,7 +1,6 @@
 # This compose file starts FROST as separate modules.
 # It also enables basic auth with the default users (read, write and admin),
 # and starts a pgadmin on port 80, with username 'example@example.com' and password 'admin'.
-version: '3'
 
 services:
   web:

--- a/scripts/docker-compose-separated.yaml
+++ b/scripts/docker-compose-separated.yaml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   web:

--- a/scripts/docker-compose-separated.yaml
+++ b/scripts/docker-compose-separated.yaml
@@ -1,4 +1,3 @@
-
 services:
   web:
     image: fraunhoferiosb/frost-server-http:latest

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   web:

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -1,4 +1,3 @@
-
 services:
   web:
     image: fraunhoferiosb/frost-server:latest


### PR DESCRIPTION
The use of `version` at the top of configuration files for docker compose files is obsolete, and in most cases it does not have any effect. This is described here: https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements

This pull request removes the `version` element from the following YAML files in the `scripts/`directory.
- docker-compose.yaml
- docker-compose-seratated.yaml
- docker-compose-separated-basicauth.yaml

This change remove this warning when calling `docker compose up`:

```shell
`WARN[0000] /Users/.../frost-server/docker-compose.yaml: `version` is obsolete 
```
