### PR TITLE
[HELM] Fix NOTES.txt to display database installation message correctly

### DIFF
--- a/helm/frost-server/templates/NOTES.txt
+++ b/helm/frost-server/templates/NOTES.txt
@@ -9,7 +9,8 @@ IMPORTANT
     In case of using a DNS name for the FROST-Server HTTP API host, make sure to be able to resolve it by
     adding a rule either to your DNS server or your local DNS resolver (e.g. /etc/hosts in Unix-based environments).
 
-{{- if not .Values.frost.db.autoUpdate }}
+{{- if not .Values.frost.http.db.autoUpdate }}
+
     In case of a fresh database installation, you have to initialize it before using FROST-Server's services.
     You can do either by:
         - Browsing to {{ include "frost-server.http.serviceRootUrl" . }}/DatabaseStatus and clicking on the "Do Update" button


### PR DESCRIPTION
- Fix NOTES.txt to use the correct variable for autoUpdate
- Add an empty line between DNS and Database section in NOTES.txt for better readability 