### PR TITLE
merge "insert" and then "select" to a single "insert … returning *" statement

### DIFF
--- a/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/AbstractPersistenceManager.java
+++ b/FROST-Server.Core/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/AbstractPersistenceManager.java
@@ -60,21 +60,20 @@ public abstract class AbstractPersistenceManager implements PersistenceManager {
 
     @Override
     public boolean insert(Entity entity, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException {
-        boolean result = doInsert(entity, updateMode);
-        if (result) {
-            Entity newEntity = fetchEntity(
-                    entity.getEntityType(),
-                    entity.getPrimaryKeyValues());
+        Entity newEntity = doInsert(entity, updateMode);
+        if (newEntity != null) {
             newEntity.setQuery(getCoreSettings().getModelRegistry().getMessageQueryGenerator().getQueryFor(entity.getEntityType()));
             changedEntities.add(
                     new EntityChangedMessage()
                             .setEventType(EntityChangedMessage.Type.CREATE)
                             .setEntity(newEntity));
+            return true;
+        } else {
+            return false;
         }
-        return result;
     }
 
-    public abstract boolean doInsert(Entity entity, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException;
+    public abstract Entity doInsert(Entity entity, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException;
 
     @Override
     public boolean delete(PathElementEntity pathElement) throws NoSuchEntityException {

--- a/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/JooqPersistenceManager.java
+++ b/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/JooqPersistenceManager.java
@@ -55,7 +55,7 @@ public interface JooqPersistenceManager extends LiquibaseUser, PersistenceManage
 
     void doDelete(ResourcePath path, Query query);
 
-    boolean doInsert(Entity entity, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException;
+    Entity doInsert(Entity entity, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException;
 
     EntityChangedMessage doUpdate(PathElementEntity pathElement, Entity entity, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException;
 

--- a/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/MariadbPersistenceManager.java
+++ b/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/MariadbPersistenceManager.java
@@ -338,10 +338,10 @@ public class MariadbPersistenceManager extends AbstractPersistenceManager implem
     }
 
     @Override
-    public boolean doInsert(Entity entity, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException {
+    public Entity doInsert(Entity entity, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException {
         init();
         StaMainTable<?> table = getTableCollection().getTableForType(entity.getEntityType());
-        return table.insertIntoDatabase(this, entity, updateMode);
+        return table.insertIntoDatabase(this, entity, updateMode, dataSize);
     }
 
     @Override

--- a/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/PostgresPersistenceManager.java
+++ b/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/PostgresPersistenceManager.java
@@ -334,10 +334,10 @@ public class PostgresPersistenceManager extends AbstractPersistenceManager imple
     }
 
     @Override
-    public boolean doInsert(Entity entity, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException {
+    public Entity doInsert(Entity entity, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException {
         init();
         StaMainTable<?> table = getTableCollection().getTableForType(entity.getEntityType());
-        return table.insertIntoDatabase(this, entity, updateMode);
+        return table.insertIntoDatabase(this, entity, updateMode, dataSize);
     }
 
     @Override

--- a/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/tables/StaMainTable.java
+++ b/FROST-Server.SQLjooq/src/main/java/de/fraunhofer/iosb/ilt/frostserver/persistence/pgjooq/tables/StaMainTable.java
@@ -106,7 +106,7 @@ public interface StaMainTable<T extends StaMainTable<T>> extends StaTable<T> {
 
     public Entity entityFromQuery(Record tuple, QueryState<T> state, DataSize dataSize);
 
-    public boolean insertIntoDatabase(JooqPersistenceManager pm, Entity entity, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException;
+    public Entity insertIntoDatabase(JooqPersistenceManager pm, Entity entity, UpdateMode updateMode, DataSize dataSize) throws NoSuchEntityException, IncompleteEntityException;
 
     public EntityChangedMessage updateInDatabase(JooqPersistenceManager pm, Entity entity, PkValue entityId, UpdateMode updateMode) throws NoSuchEntityException, IncompleteEntityException;
 


### PR DESCRIPTION
For insertion, AbstractPersistenceManager first inserts data with "INSERT INTO … RETURNING table.ID;", returns the generated 
\<ID\> and then queries the same row using \<ID\> with "SELECT * FROM table WHERE table.ID = \<ID\>;".

This requests merges these two operations into one single operation: "INSERT INTO … RETURNING table.*;" Hereby data is inserted, altered by rules or before-triggers (not after-triggers!), should there be any, and then immediately returned. It eliminates the need for another SELECT statement.


(Background: For the default implementation of FROST, this is not noticeable. However when trying to extend the database with TimescaleDB, this small detail speeds up writes significantly.)