### PR TITLE
FROST deployment improvements for lifecycle actions

### DIFF
--- a/FROST-Server.HTTP/Dockerfile
+++ b/FROST-Server.HTTP/Dockerfile
@@ -13,6 +13,7 @@ RUN unzip -d ${CATALINA_HOME}/webapps/FROST-Server /tmp/FROST-Server.war \
     && groupadd --system --gid 1001 tomcat \
     && useradd --system --uid 1001 --gid 1001 tomcat \
     && chgrp -R 0 $CATALINA_HOME \
-    && chmod -R g=u $CATALINA_HOME
+    && chmod -R g=u $CATALINA_HOME \
+    && chown tomcat:tomcat /use/local/tomcat/lib/security/cacerts
 
 USER tomcat

--- a/FROST-Server.MQTTP/Dockerfile
+++ b/FROST-Server.MQTTP/Dockerfile
@@ -13,6 +13,7 @@ RUN unzip -d ${CATALINA_HOME}/webapps/FROST-Server /tmp/FROST-Server.war \
     && groupadd --system --gid 1001 tomcat \
     && useradd --system --uid 1001 --gid 1001 tomcat \
     && chgrp -R 0 $CATALINA_HOME \
-    && chmod -R g=u $CATALINA_HOME
+    && chmod -R g=u $CATALINA_HOME \
+    && chown tomcat:tomcat /use/local/tomcat/lib/security/cacerts
 
 USER tomcat

--- a/helm/build.sh
+++ b/helm/build.sh
@@ -7,16 +7,16 @@ git config --global user.name "Workflow Build"
 # release version
 if [[ "${GITHUB_BASE_REF}" == "" ]] && [[ "${GITHUB_REF}" == "refs/tags"* ]]; then
   echo "Building release helm chart"
-  git clone --quiet --branch master https://github.com/FraunhoferIOSB/helm-charts.git
+  git clone --quiet --branch master https://github.com/kernblick/helm-charts.git
   /tmp/helm lint ./helm/frost-server
   /tmp/helm package ./helm/frost-server -d ./helm-charts
-  /tmp/helm repo index --url https://fraunhoferiosb.github.io/helm-charts/ ./helm-charts
+  /tmp/helm repo index --url https://kernblick.github.io/helm-charts/ ./helm-charts
 fi
 
 echo "Building snapshot helm chart"
-git clone --quiet --branch master https://github.com/FraunhoferIOSB/helm-charts-snapshot.git
+git clone --quiet --branch master https://github.com/kernblick/helm-charts-snapshot.git
 /tmp/helm lint ./helm/frost-server
 /tmp/helm package ./helm/frost-server -d ./helm-charts-snapshot
-/tmp/helm repo index --url https://fraunhoferiosb.github.io/helm-charts-snapshot/ ./helm-charts-snapshot
+/tmp/helm repo index --url https://kernblick.github.io/helm-charts-snapshot/ ./helm-charts-snapshot
 
 echo "Helm chart build"

--- a/helm/frost-server/Chart.yaml
+++ b/helm/frost-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: frost-server
-version: 2.5.0
-appVersion: 2.5.0
+version: 2.5.1
+appVersion: 2.5.1
 description: The FROST-Server (FRaunhofer Opensource SensorThings-Server) is the first complete, open-source implementation of the OGC SensorThings API Part 1 (Sensing).
 keywords:
   - sensorthings-api

--- a/helm/frost-server/templates/http-deployment.yaml
+++ b/helm/frost-server/templates/http-deployment.yaml
@@ -32,10 +32,19 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.frost.http.image.imagePullSecret }}
       {{- end}}
+      {{- if .Values.frost.http.volumes }}
+      volumes: {{ .Values.frost.http.volumes }}
+      {{- end}}
       containers:
         - name: {{ $fullName }}
           image: "{{ .Values.frost.http.image.registry }}/{{ .Values.frost.http.image.repository }}:{{ .Values.frost.http.image.tag }}"
           imagePullPolicy: {{ .Values.frost.http.image.pullPolicy | quote }}
+          {{- if .Values.frost.http.lifecycle }}
+          lifecycle: {{ .Values.frost.http.lifecycle }}
+          {{- end}}
+          {{- if .Values.frost.http.volumeMounts }}
+          lifecycle: {{ .Values.frost.http.volumeMounts }}
+          {{- end}}
           ports:
             - name: tomcat
               containerPort: 8080

--- a/helm/frost-server/templates/http-deployment.yaml
+++ b/helm/frost-server/templates/http-deployment.yaml
@@ -33,20 +33,20 @@ spec:
         - name: {{ .Values.frost.http.image.imagePullSecret }}
       {{- end}}
       {{- if .Values.frost.http.volumes }}
-      volumes: {{ .Values.frost.http.volumes }}
+      volumes: {{ toYaml .Values.frost.http.volumes | nindent 12 }}
       {{- end}}
       containers:
         - name: {{ $fullName }}
           image: "{{ .Values.frost.http.image.registry }}/{{ .Values.frost.http.image.repository }}:{{ .Values.frost.http.image.tag }}"
           imagePullPolicy: {{ .Values.frost.http.image.pullPolicy | quote }}
           {{- if .Values.frost.http.lifecycle }}
-          lifecycle: {{ .Values.frost.http.lifecycle }}
+          lifecycle: {{ toYaml .Values.frost.http.lifecycle | nindent 12 }}
           {{- end}}
           {{- if .Values.frost.http.securityContext }}
-          securityContext: {{ .Values.frost.http.securityContext }}
+          securityContext: {{ toYaml .Values.frost.http.securityContext | nindent 12 }}
           {{- end}}
           {{- if .Values.frost.http.volumeMounts }}
-          lifecycle: {{ .Values.frost.http.volumeMounts }}
+          volumeMounts: {{ toYaml .Values.frost.http.volumeMounts | nindent 12 }}
           {{- end}}
           ports:
             - name: tomcat

--- a/helm/frost-server/templates/http-deployment.yaml
+++ b/helm/frost-server/templates/http-deployment.yaml
@@ -42,6 +42,9 @@ spec:
           {{- if .Values.frost.http.lifecycle }}
           lifecycle: {{ .Values.frost.http.lifecycle }}
           {{- end}}
+          {{- if .Values.frost.http.securityContext }}
+          securityContext: {{ .Values.frost.http.securityContext }}
+          {{- end}}
           {{- if .Values.frost.http.volumeMounts }}
           lifecycle: {{ .Values.frost.http.volumeMounts }}
           {{- end}}

--- a/helm/frost-server/templates/http-service.yaml
+++ b/helm/frost-server/templates/http-service.yaml
@@ -17,13 +17,13 @@ spec:
     helm.sh/chart: {{ include "frost-server.chart" . }}
     app: {{ include "frost-server.name" . }}
     component: {{ $tier }}
-  {{- if not .Values.frost.http.ingress.enabled }}
+  {{- if eq .Values.frost.mqtt.serviceType "NodePort" }}
   type: NodePort
   {{- end }}
   ports:
     - name: http
       port: {{ .Values.frost.http.ports.http.servicePort }}
-      {{- if not .Values.frost.http.ingress.enabled }}
+      {{- if eq .Values.frost.mqtt.serviceType "NodePort" && .Values.frost.http.ports.http.nodePort }}
       nodePort: {{ .Values.frost.http.ports.http.nodePort }}
       {{- end }}
       targetPort: tomcat

--- a/helm/frost-server/templates/http-service.yaml
+++ b/helm/frost-server/templates/http-service.yaml
@@ -23,7 +23,7 @@ spec:
   ports:
     - name: http
       port: {{ .Values.frost.http.ports.http.servicePort }}
-      {{- if eq .Values.frost.mqtt.serviceType "NodePort" && .Values.frost.http.ports.http.nodePort }}
+      {{- if eq .Values.frost.mqtt.serviceType "NodePort" }}
       nodePort: {{ .Values.frost.http.ports.http.nodePort }}
       {{- end }}
       targetPort: tomcat

--- a/helm/frost-server/templates/mqtt-deployment.yaml
+++ b/helm/frost-server/templates/mqtt-deployment.yaml
@@ -32,10 +32,19 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.frost.mqtt.image.imagePullSecret }}
       {{- end}}
+      {{- if .Values.frost.mqtt.volumes }}
+      volumes: {{ .Values.frost.mqtt.volumes }}
+      {{- end}}
       containers:
         - name: {{ $fullName }}
           image: "{{ .Values.frost.mqtt.image.registry }}/{{ .Values.frost.mqtt.image.repository }}:{{ .Values.frost.mqtt.image.tag }}"
           imagePullPolicy: {{ .Values.frost.mqtt.image.pullPolicy | quote }}
+          {{- if .Values.frost.mqtt.lifecycle }}
+          lifecycle: {{ .Values.frost.mqtt.lifecycle }}
+          {{- end}}
+          {{- if .Values.frost.mqtt.volumeMounts }}
+          lifecycle: {{ .Values.frost.mqtt.volumeMounts }}
+          {{- end}}
           ports:
             - name: mqtt
               containerPort: 1883

--- a/helm/frost-server/templates/mqtt-deployment.yaml
+++ b/helm/frost-server/templates/mqtt-deployment.yaml
@@ -332,7 +332,8 @@ spec:
             {{ else }}
             - name: auth_db_url
               value: "{{ .Values.frost.db.dbExternalConnectionString }}"
-            {{ end }}            - name: auth_autoUpdateDatabase
+            {{ end }}
+            - name: auth_autoUpdateDatabase
               value: "{{tpl .Values.frost.auth.db.autoUpdate . }}"
             - name: auth_db_conn_max
               value: "{{ .Values.frost.http.db.maximumConnection }}"

--- a/helm/frost-server/templates/mqtt-deployment.yaml
+++ b/helm/frost-server/templates/mqtt-deployment.yaml
@@ -45,6 +45,9 @@ spec:
           {{- if .Values.frost.mqtt.volumeMounts }}
           lifecycle: {{ .Values.frost.mqtt.volumeMounts }}
           {{- end}}
+          {{- if .Values.frost.mqtt.securityContext }}
+          securityContext: {{ .Values.frost.mqtt.securityContext }}
+          {{- end}}
           ports:
             - name: mqtt
               containerPort: 1883

--- a/helm/frost-server/templates/mqtt-deployment.yaml
+++ b/helm/frost-server/templates/mqtt-deployment.yaml
@@ -33,20 +33,20 @@ spec:
         - name: {{ .Values.frost.mqtt.image.imagePullSecret }}
       {{- end}}
       {{- if .Values.frost.mqtt.volumes }}
-      volumes: {{ .Values.frost.mqtt.volumes }}
+      volumes: {{ toYaml .Values.frost.mqtt.volumes | nindent 12 }}
       {{- end}}
       containers:
         - name: {{ $fullName }}
           image: "{{ .Values.frost.mqtt.image.registry }}/{{ .Values.frost.mqtt.image.repository }}:{{ .Values.frost.mqtt.image.tag }}"
           imagePullPolicy: {{ .Values.frost.mqtt.image.pullPolicy | quote }}
           {{- if .Values.frost.mqtt.lifecycle }}
-          lifecycle: {{ .Values.frost.mqtt.lifecycle }}
+          lifecycle: {{ toYaml .Values.frost.mqtt.lifecycle | nindent 12 }}
           {{- end}}
           {{- if .Values.frost.mqtt.volumeMounts }}
-          lifecycle: {{ .Values.frost.mqtt.volumeMounts }}
+          volumeMounts: {{ toYaml .Values.frost.mqtt.volumeMounts | nindent 12 }}
           {{- end}}
           {{- if .Values.frost.mqtt.securityContext }}
-          securityContext: {{ .Values.frost.mqtt.securityContext }}
+          securityContext: {{ toYaml .Values.frost.mqtt.securityContext | nindent 12 }}
           {{- end}}
           ports:
             - name: mqtt

--- a/helm/frost-server/templates/mqtt-deployment.yaml
+++ b/helm/frost-server/templates/mqtt-deployment.yaml
@@ -326,9 +326,13 @@ spec:
               value: ""
             - name: auth_db_driver
               value: "{{ .Values.frost.db.driver }}"
+            {{ if .Values.frost.db.enableIntegratedDb }}
             - name: auth_db_url
               value: {{ printf "jdbc:postgresql://%s:5432/%s" (include "frost-server.fullName" (merge (dict "tier" "db") .)) .Values.frost.db.database | quote }}
-            - name: auth_autoUpdateDatabase
+            {{ else }}
+            - name: auth_db_url
+              value: "{{ .Values.frost.db.dbExternalConnectionString }}"
+            {{ end }}            - name: auth_autoUpdateDatabase
               value: "{{tpl .Values.frost.auth.db.autoUpdate . }}"
             - name: auth_db_conn_max
               value: "{{ .Values.frost.http.db.maximumConnection }}"

--- a/helm/frost-server/values.yaml
+++ b/helm/frost-server/values.yaml
@@ -143,6 +143,14 @@ frost:
         cpu: 500m
         memory: 1Gi
 
+    # FROST-Server HTTP lifecycle options.
+    lifecycle: {}
+
+    # FROST-Server HTTP volumeMounts options.
+    volumeMounts: {}
+
+    # FROST-Server HTTP volumes.
+    volumes: {}
 
     # FROST-Server HTTP business settings
     serviceHost: frost-server
@@ -253,6 +261,15 @@ frost:
       recvWorkerPoolSize: 10
       recvQueueSize: 2000
       maxInFlight: 50
+
+    # FROST-Server MQTT lifecycle options.
+    lifecycle: {}
+
+    # FROST-Server MQTT volumeMounts options.
+    volumeMounts: {}
+
+    # FROST-Server MQTT volumes.
+    volumes: {}
 
     ingress:
       enabled: false

--- a/helm/frost-server/values.yaml
+++ b/helm/frost-server/values.yaml
@@ -145,13 +145,13 @@ frost:
         memory: 1Gi
 
     # FROST-Server HTTP lifecycle options.
-    lifecycle: {}
+    lifecycle:
 
     # FROST-Server HTTP volumeMounts options.
-    volumeMounts: {}
+    volumeMounts:
 
     # FROST-Server HTTP volumes.
-    volumes: {}
+    volumes:
 
     securityContext:
 
@@ -266,13 +266,13 @@ frost:
       maxInFlight: 50
 
     # FROST-Server MQTT lifecycle options.
-    lifecycle: {}
+    lifecycle:
 
     # FROST-Server MQTT volumeMounts options.
-    volumeMounts: {}
+    volumeMounts:
 
     # FROST-Server MQTT volumes.
-    volumes: {}
+    volumes:
 
     securityContext:
 

--- a/helm/frost-server/values.yaml
+++ b/helm/frost-server/values.yaml
@@ -153,6 +153,8 @@ frost:
     # FROST-Server HTTP volumes.
     volumes: {}
 
+    securityContext:
+
     # FROST-Server HTTP business settings
     serviceHost: frost-server
     serviceProtocol: http
@@ -271,6 +273,8 @@ frost:
 
     # FROST-Server MQTT volumes.
     volumes: {}
+
+    securityContext:
 
     ingress:
       enabled: false

--- a/helm/frost-server/values.yaml
+++ b/helm/frost-server/values.yaml
@@ -120,6 +120,7 @@ frost:
       imagePullSecret:
     # FROST-Server HTTP deployment settings
     replicas: 1
+    serviceType: ClusterIP
     ports:
       http:
         nodePort:

--- a/helm/upload.sh
+++ b/helm/upload.sh
@@ -14,7 +14,7 @@ if [[ "${GITHUB_BASE_REF}" == "" ]] && [[ "${GITHUB_REF}" == "refs/tags"* ]]; th
   cd helm-charts
   git add .
   git remote rm origin
-  git remote add origin git@github.com:FraunhoferIOSB/helm-charts.git
+  git remote add origin git@github.com:kernblick/helm-charts.git
   git commit -m "Github build ${GITHUB_RUN_NUMBER} pushed"
   git push origin master -fq
   cd ../
@@ -31,7 +31,7 @@ if [[ "${GITHUB_BASE_REF}" == "" ]] && ([[ "${GITHUB_REF}" == "${DEFAULT_BRANCH}
     cd helm-charts-snapshot
     git add .
     git remote rm origin
-    git remote add origin git@github.com:FraunhoferIOSB/helm-charts-snapshot.git
+    git remote add origin git@github.com:kernblick/helm-charts-snapshot.git
     git commit -m "Github build ${GITHUB_RUN_NUMBER} pushed"
     git push origin master -fq
     cd ../

--- a/helm/upload.sh
+++ b/helm/upload.sh
@@ -23,7 +23,7 @@ if [[ "${GITHUB_BASE_REF}" == "" ]] && [[ "${GITHUB_REF}" == "refs/tags"* ]]; th
 fi
 
 # Only deploy master branch and tagged builds to snapshot repository
-if [[ "${GITHUB_BASE_REF}" == "" ]] && ([[ "${GITHUB_REF}" == "${DEFAULT_BRANCH}" ]] || [[ "${GITHUB_REF}" == "refs/tags"* ]] || [[ "${GITHUB_REF}" == "develop-2.x" ]]); then
+if [[ "${GITHUB_BASE_REF}" == "" ]] && ([[ "${GITHUB_REF}" == "${DEFAULT_BRANCH}" ]] || [[ "${GITHUB_REF}" == "refs/tags"* ]] || [[ "${GITHUB_REF}" == "refs/heads/develop-2.x" ]]); then
 
     echo -e "${HELM_SSH_KEY_SNAPSHOT}" > ~/.ssh/id_rsa
     chmod 600 ~/.ssh/id_rsa

--- a/helm/upload.sh
+++ b/helm/upload.sh
@@ -23,7 +23,7 @@ if [[ "${GITHUB_BASE_REF}" == "" ]] && [[ "${GITHUB_REF}" == "refs/tags"* ]]; th
 fi
 
 # Only deploy master branch and tagged builds to snapshot repository
-if [[ "${GITHUB_BASE_REF}" == "" ]] && ([[ "${GITHUB_REF}" == "${DEFAULT_BRANCH}" ]] || [[ "${GITHUB_REF}" == "refs/tags"* ]]); then
+if [[ "${GITHUB_BASE_REF}" == "" ]] && ([[ "${GITHUB_REF}" == "${DEFAULT_BRANCH}" ]] || [[ "${GITHUB_REF}" == "refs/tags"* ]] || [[ "${GITHUB_REF}" == "develop-2.x" ]]); then
 
     echo -e "${HELM_SSH_KEY_SNAPSHOT}" > ~/.ssh/id_rsa
     chmod 600 ~/.ssh/id_rsa

--- a/helm/upload.sh
+++ b/helm/upload.sh
@@ -5,7 +5,7 @@ set -e
 mkdir -p ~/.ssh
 ssh-keyscan -H github.com >> ~/.ssh/known_hosts
 
-echo "Running for branch: ${GITHUB_REF}"
+echo "Running for branch: ${GITHUB_REF} / ${GITHUB_BASE_REF}"
 
 # release version
 if [[ "${GITHUB_BASE_REF}" == "" ]] && [[ "${GITHUB_REF}" == "refs/tags"* ]]; then


### PR DESCRIPTION
### Summary

This pull request implements improvements to the FROST deployment configuration to better support environments using a custom CA certificate. These changes address several challenges encountered during deployment with self-signed certificates, especially relevant in setups with reverse proxies or internal deployments with self-managed CA certificates.

### Background

In certain deployment scenarios, such as local environments or customer installations behind a reverse proxy, the platform may utilize a self-signed certificate. FROST interacts with Keycloak via the IDM's well-known endpoint (`idm.<DOMAIN>/auth/.../well-known...`), which uses this self-signed certificate. To ensure successful communication, this certificate must be added to the JDK’s `cacerts` store. This is achieved using `keytool`.

### Changes

To facilitate this in our deployment, we added a `lifecycle.postStart` action, which invokes `keytool` to add the self-signed certificate. However, the default setup of the Tomcat container creates the `cacerts` store under the root user, making it necessary to run the container as root, which is less secure and introduces additional complexity.

The following changes are proposed to the Helm chart for a more seamless deployment experience:

1. **New Keys in the Values File**:
   - `spec.template.spec.containers.<cnt>.lifecycle`
   - `spec.template.spec.containers.<cnt>.volumeMounts`
   - `spec.template.spec.volumes`

2. **Permissions Update for `cacerts`**:
   - Assign ownership of the `cacerts` file in `/usr/local/tomcat/lib/security/` to the `tomcat` user (`1001`), allowing non-root execution for better security.

---

### Note

Files `build.sh` and `upload.sh` are not included in this PR, as they are not part of these configuration updates.