### PR TITLE
Remove trailing slash from MQTT endpoint by default

### DIFF
--- a/helm/frost-server/templates/_helpers.tpl
+++ b/helm/frost-server/templates/_helpers.tpl
@@ -77,9 +77,9 @@ Get the MQTT Websock-Path.
 */}}
 {{- define "frost-server.mqtt.websockPath" -}}
   {{- if not .Values.frost.mqtt.urlSubPath | empty -}}
-      {{- printf "/%s/" .Values.frost.mqtt.urlSubPath | replace "//" "/" -}}
+      {{- printf "/%s" .Values.frost.mqtt.urlSubPath | replace "//" "/" -}}
   {{- else -}}
-      {{- printf "/mqtt/" -}}
+      {{- printf "/mqtt" -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
The URL scheme expected by many MQTT client libraries is `(mqtt|ws)[s]:/<host>[:<port>]/.../mqtt`, i.e. ending in `/mqtt`.

With v2.5.0 a trailing slash is enforced when deploying using the Helm Chart!

This leads to problems when trying to establish a WebSocket-based MQTT connections. For example, nginx returns HTTP status sode 301 (Permanently moved).

The fix is to simply remove the trailing slash by default.