### PR TITLE
add default annotations and possibility to use same ingress for http-…

### DIFF
--- a/helm/frost-server/templates/NOTES.txt
+++ b/helm/frost-server/templates/NOTES.txt
@@ -32,7 +32,7 @@ Hereafter the list of available exposed FROST-Server's resources:
 FROST-Server's resource     | Access URL
 --------------------------- | ----------------------------------------------
 HTTP - Homepage             | {{ include "frost-server.http.serviceRootUrl" . }}
-HTTP - SensorThings API     | {{ include "frost-server.http.serviceRootUrl" . }}{{ include "frost-server.http.apiVersion" . }}
+HTTP - SensorThings API     | {{ include "frost-server.http.serviceRootUrl" . }}/{{ include "frost-server.http.apiVersion" . }}
 {{- if .Values.frost.mqtt.enabled }}
 MQTT - TCP                  | {{ include "frost-server.mqtt.serviceEndpoint" . }}
 MQTT - Websocket            | {{ include "frost-server.mqtt.serviceRootUrl" . }}

--- a/helm/frost-server/templates/_helpers.tpl
+++ b/helm/frost-server/templates/_helpers.tpl
@@ -12,8 +12,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "frost-server.fullName" -}}
 {{- $name := default .Chart.Name .Values.name -}}
-{{- if .tier -}}
+{{- if and .tier (not .merge) -}}
 {{- printf "%s-%s-%s" .Release.Name $name .tier | trunc 63 | trimSuffix "-" -}}
+{{- else if .merge -}}
+{{- printf "%s-%s-minion-%s" .Release.Name $name .tier | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -148,7 +150,7 @@ Get the default agic rewriteAnnotations for ingress.
       {{/* put here default annotations for http-service */}}
     {{- else if eq .type "mqtt" -}}
       {{- $_ := set $myannotations "nginx.org/websocket-services" .fullName -}}
-      {{- $_ := set $myannotations "nginx.org/proxy-set-headers" (printf "proxy_cache_bypass: $http_upgrade" ) -}}
+      {{- $_ := set $myannotations "nginx.org/location-snippets" (printf "proxy_cache_bypass $http_upgrade" ) -}}
       {{- $_ := set $myannotations "nginx.org/proxy-read-timeout" "3600" -}}
       {{- $_ := set $myannotations "nginx.org/proxy-send-timeout" "3600" -}}
       {{/* put here default annotations for mqtt-service */}}

--- a/helm/frost-server/templates/_helpers.tpl
+++ b/helm/frost-server/templates/_helpers.tpl
@@ -65,7 +65,11 @@ Get the HTTP service SubPath
 Get the MQTT serviceHost.
 */}}
 {{- define "frost-server.mqtt.serviceHost" -}}
-  {{ if not .Values.frost.mqtt.serviceHost | empty }}{{ .Values.frost.mqtt.serviceHost }}{{else}}{{ .Values.frost.http.serviceHost }}{{end}}
+  {{- if or .Values.frost.mqtt.ingress.useSameAsHttp ( .Values.frost.mqtt.serviceHost | empty ) -}}
+    {{- printf "%s" .Values.frost.http.serviceHost -}}
+  {{- else -}}
+    {{- printf "%s" .Values.frost.mqtt.serviceHost -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*
@@ -140,10 +144,12 @@ Get the default agic rewriteAnnotations for ingress.
     {{- end -}}
     {{- if eq .type "http" -}}
       {{- $_ := set $myannotations "nginx.org/rewrites" (printf "serviceName=%s rewrite=/FROST-Server" .fullName ) -}}
+      {{- $_ := set $myannotations "nginx.org/proxy-set-headers" (printf "X-Forwarded-Path: %s" .path ) -}}
       {{/* put here default annotations for http-service */}}
     {{- else if eq .type "mqtt" -}}
       {{- $_ := set $myannotations "nginx.org/websocket-services" .fullName -}}
-	  {{- $_ := set $myannotations "nginx.org/proxy-read-timeout" "3600" -}}
+      {{- $_ := set $myannotations "nginx.org/proxy-set-headers" (printf "proxy_cache_bypass: $http_upgrade" ) -}}
+      {{- $_ := set $myannotations "nginx.org/proxy-read-timeout" "3600" -}}
       {{- $_ := set $myannotations "nginx.org/proxy-send-timeout" "3600" -}}
       {{/* put here default annotations for mqtt-service */}}
     {{- end -}}

--- a/helm/frost-server/templates/_helpers.tpl
+++ b/helm/frost-server/templates/_helpers.tpl
@@ -104,8 +104,16 @@ Get the MQTT TCP service EndPoint
 Get the default agic rewriteAnnotations for ingress.
 */}}
 {{- define "frost-server.ingress.rewriteAnnotation" -}}
-  {{- $myannotations := dict -}}  
-  {{- if eq .scope.ingress.ingressProvider "agic" -}} {{/* Set annotations for ingress of type azure agic */}}
+  {{- $myannotations := dict -}} 
+  {{- $ingressProvider := "default" -}} 
+  {{- if and .scope.ingress.ingressProvider ( not .combine ) -}}
+    {{- $ingressProvider = .scope.ingress.ingressProvider -}}
+  {{- else if .combine -}}
+    {{- if .combine.ingress.ingressProvider -}}
+      {{- $ingressProvider = .combine.ingress.ingressProvider -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if eq $ingressProvider "agic" -}} {{/* Set annotations for ingress of type azure agic */}}
     {{- if .scope.ingress.tls.enabled -}}
       {{- $_ := set $myannotations "appgw.ingress.kubernetes.io/ssl-redirect" "true" -}}
     {{- end -}}
@@ -114,8 +122,9 @@ Get the default agic rewriteAnnotations for ingress.
       {{/* put here default annotations for http-service */}}
     {{- else if eq .type "mqtt" -}}
       {{/* put here default annotations for mqtt-service */}}
+      {{/* AGIV seems to be (out of the box) able to handle websocket without additional annotations*/}}
     {{- end -}}
-  {{- else if eq .scope.ingress.ingressProvider "traefik" -}} {{/* Set annotations for ingress of type traefik */}}
+  {{- else if eq $ingressProvider "traefik" -}} {{/* Set annotations for ingress of type traefik */}}
     {{- if .scope.ingress.tls.enabled -}}
       {{- $_ := set $myannotations "traefik.ingress.kubernetes.io/router.tls" "true" -}}
     {{- end -}}
@@ -123,8 +132,20 @@ Get the default agic rewriteAnnotations for ingress.
       {{/* put here default annotations for http-service */}}
     {{- else if eq .type "mqtt" -}}
       {{/* put here default annotations for mqtt-service */}}
+      {{/* TRAEFIK seems to be (out of the box) able to handle websockets without additional annotations*/}}
     {{- end -}}
-  {{- else if eq .scope.ingress.ingressProvider "nginx" -}} {{/* Set annotations for ingress of type kubernetes.nginx */}}
+  {{- else if eq $ingressProvider "nginx-nginx" -}} {{/* Set annotations for ingress of type nginx.nginx */}}
+    {{- if .scope.ingress.tls.enabled -}}
+      {{- $_ := set $myannotations "nginx.ingress.kubernetes.io/ssl-redirect" "true" -}}
+    {{- end -}}
+    {{- if eq .type "http" -}}
+      {{- $_ := set $myannotations "nginx.org/rewrites" (printf "serviceName=%s rewrite=/FROST-Server" .fullName ) -}}
+      {{/* put here default annotations for http-service */}}
+    {{- else if eq .type "mqtt" -}}
+      {{- $_ := set $myannotations "nginx.org/websocket-services" .fullName -}}
+      {{/* put here default annotations for mqtt-service */}}
+    {{- end -}}
+  {{- else if or (eq $ingressProvider "kubernetes-nginx") (eq $ingressProvider "default") -}} {{/* Set annotations for ingress of type kubernetes.nginx */}}
     {{- if .scope.ingress.tls.enabled -}}
       {{- $_ := set $myannotations "nginx.ingress.kubernetes.io/ssl-redirect" "true" -}}
     {{- end -}}
@@ -132,7 +153,8 @@ Get the default agic rewriteAnnotations for ingress.
       {{- $_ := set $myannotations "nginx.ingress.kubernetes.io/rewrite-target" "/FROST-Server/$1" -}}
       {{/* put here default annotations for http-service */}}
     {{- else if eq .type "mqtt" -}}
-      {{- $_ := set $myannotations "nginx.mqtt.hamel.test" "true" -}}
+      {{- $_ := set $myannotations "nginx.ingress.kubernetes.io/proxy-read-timeout" "3600" -}}
+      {{- $_ := set $myannotations "nginx.ingress.kubernetes.io/proxy-send-timeout" "3600" -}}
       {{/* put here default annotations for mqtt-service */}}
     {{- end -}}
   {{- end -}}

--- a/helm/frost-server/templates/_helpers.tpl
+++ b/helm/frost-server/templates/_helpers.tpl
@@ -143,6 +143,8 @@ Get the default agic rewriteAnnotations for ingress.
       {{/* put here default annotations for http-service */}}
     {{- else if eq .type "mqtt" -}}
       {{- $_ := set $myannotations "nginx.org/websocket-services" .fullName -}}
+	  {{- $_ := set $myannotations "nginx.org/proxy-read-timeout" "3600" -}}
+      {{- $_ := set $myannotations "nginx.org/proxy-send-timeout" "3600" -}}
       {{/* put here default annotations for mqtt-service */}}
     {{- end -}}
   {{- else if or (eq $ingressProvider "kubernetes-nginx") (eq $ingressProvider "default") -}} {{/* Set annotations for ingress of type kubernetes.nginx */}}

--- a/helm/frost-server/templates/http-ingress.yaml
+++ b/helm/frost-server/templates/http-ingress.yaml
@@ -1,12 +1,7 @@
 {{- if .Values.frost.http.ingress.enabled -}}
 {{- $tier := "http" -}}
 {{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
-{{- $defaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.http "type" $tier "fullName" $fullName) -}}
-{{- /*Begin of mqtt definition used if same ingress is used*/ -}}
-{{- $mqtier := "mqtt" -}}
-{{- $mqfullName := include "frost-server.fullName" (merge (dict "tier" $mqtier) .) -}}
-{{- $mqdefaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.mqtt "type" $mqtier "fullName" $mqfullName "combine" .Values.frost.http) -}}
-{{- /*End of mqtt definition used if same ingress is used*/ -}}
+{{- $defaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.http "type" $tier "fullName" $fullName "path" ( include "frost-server.http.serviceSubPath" . ) ) -}}
 {{- /*BEGIN Predefine empty variables*/ -}}
 {{- $annotations := dict -}}
 {{- /*END Predefine empty variables*/ -}}
@@ -26,16 +21,15 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.frost.mqtt.ingress.useSameAsHttp }}
-  {{- $annotations = include "common.tplvalues.merge" ( dict "values" ( list .Values.frost.http.ingress.annotations $mqdefaultRewriteAnnotations $defaultRewriteAnnotations ) "context" . ) }}
-  {{- else }}
   {{- $annotations = include "common.tplvalues.merge" ( dict "values" ( list .Values.frost.http.ingress.annotations $defaultRewriteAnnotations ) "context" . ) }}
-  {{- end }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- if .Values.frost.mqtt.ingress.useSameAsHttp }}
+    nginx.org/mergeable-ingress-type: "master"
+  {{- end }}
   {{- /*Following annotation can't be described in the _helpers.tpl, so actually it hast to stay here*/ -}}
   {{- if and .Values.frost.mqtt.ingress.useSameAsHttp (or (eq .Values.frost.http.ingress.ingressProvider "kubernetes-nginx") (not .Values.frost.http.ingress.ingressProvider))}}
     nginx.ingress.kubernetes.io/server-snippets: |
-        location / {
+        location {{ template "frost-server.mqtt.websockPath" . }} {
           proxy_set_header Upgrade $http_upgrade;
           proxy_http_version 1.1;
           proxy_set_header X-Forwarded-Host $http_host;
@@ -73,14 +67,4 @@ spec:
             name:  {{ $fullName }}
             port:
               number: {{ .Values.frost.http.ports.http.servicePort }}
-    {{- /* Defines the additional path if same ingress for http and mqtt ingress is set*/ -}}
-    {{- if .Values.frost.mqtt.ingress.useSameAsHttp }}
-      - path: {{ template "frost-server.mqtt.websockPath" . }}
-        pathType: Prefix
-        backend:
-          service:
-            name:  {{ $mqfullName }}
-            port:
-              number: {{ .Values.frost.mqtt.ports.websocket.servicePort }}
-    {{- end -}}
 {{- end -}}

--- a/helm/frost-server/templates/http-ingress.yaml
+++ b/helm/frost-server/templates/http-ingress.yaml
@@ -1,7 +1,15 @@
 {{- if .Values.frost.http.ingress.enabled -}}
 {{- $tier := "http" -}}
 {{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
-{{- $defaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.http "type" "http") -}}
+{{- $defaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.http "type" $tier "fullName" $fullName) -}}
+{{- /*Begin of mqtt definition used if same ingress is used*/ -}}
+{{- $mqtier := "mqtt" -}}
+{{- $mqfullName := include "frost-server.fullName" (merge (dict "tier" $mqtier) .) -}}
+{{- $mqdefaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.mqtt "type" $mqtier "fullName" $mqfullName "combine" .Values.frost.http) -}}
+{{- /*End of mqtt definition used if same ingress is used*/ -}}
+{{- /*BEGIN Predefine empty variables*/ -}}
+{{- $annotations := dict -}}
+{{- /*END Predefine empty variables*/ -}}
 {{- if and .Values.frost.http.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.frost.http.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.frost.http.ingress.annotations "kubernetes.io/ingress.class" .Values.frost.http.ingress.className}}
@@ -18,8 +26,26 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   namespace: {{ .Release.Namespace }}
-  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.frost.http.ingress.annotations $defaultRewriteAnnotations ) "context" . ) }}
+  {{- if .Values.frost.mqtt.ingress.useSameAsHttp }}
+  {{- $annotations = include "common.tplvalues.merge" ( dict "values" ( list .Values.frost.http.ingress.annotations $mqdefaultRewriteAnnotations $defaultRewriteAnnotations ) "context" . ) }}
+  {{- else }}
+  {{- $annotations = include "common.tplvalues.merge" ( dict "values" ( list .Values.frost.http.ingress.annotations $defaultRewriteAnnotations ) "context" . ) }}
+  {{- end }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- /*Following annotation can't be described in the _helpers.tpl, so actually it hast to stay here*/ -}}
+  {{- if and .Values.frost.mqtt.ingress.useSameAsHttp (or (eq .Values.frost.http.ingress.ingressProvider "kubernetes-nginx") (not .Values.frost.http.ingress.ingressProvider))}}
+    nginx.ingress.kubernetes.io/server-snippets: |
+        location / {
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_http_version 1.1;
+          proxy_set_header X-Forwarded-Host $http_host;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header X-Forwarded-For $remote_addr;
+          proxy_set_header Host $host;
+          proxy_set_header Connection "upgrade";
+          proxy_cache_bypass $http_upgrade;
+        }
+  {{- end }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -34,19 +60,27 @@ spec:
   tls:
     - hosts: 
         - {{ include "frost-server.http.serviceHost" . }}
-    {{- if .Values.frost.http.ingress.tls.secretName }}
       secretName: {{ .Values.frost.http.ingress.tls.secretName }}
-    {{- end -}}
   {{- end }}
   rules:
   - host: {{ include "frost-server.http.serviceHost" . }}
     http:
       paths:
-      - path:  {{ template "frost-server.http.serviceSubPath" . }}
+      - path: {{ template "frost-server.http.serviceSubPath" . }}
         pathType: Prefix
         backend:
           service:
             name:  {{ $fullName }}
             port:
               number: {{ .Values.frost.http.ports.http.servicePort }}
+    {{- /* Defines the additional path if same ingress for http and mqtt ingress is set*/ -}}
+    {{- if .Values.frost.mqtt.ingress.useSameAsHttp }}
+      - path: {{ template "frost-server.mqtt.websockPath" . }}
+        pathType: Prefix
+        backend:
+          service:
+            name:  {{ $mqfullName }}
+            port:
+              number: {{ .Values.frost.mqtt.ports.websocket.servicePort }}
+    {{- end -}}
 {{- end -}}

--- a/helm/frost-server/templates/master-ingress.yaml
+++ b/helm/frost-server/templates/master-ingress.yaml
@@ -1,6 +1,6 @@
-{{- if .Values.frost.http.ingress.enabled -}}
-{{- $tier := "http" -}}
-{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier "merge" .Values.frost.mqtt.ingress.useSameAsHttp ) .) -}}
+{{- if and .Values.frost.http.ingress.enabled .Values.frost.mqtt.ingress.useSameAsHttp -}}
+{{- $tier := "master" -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
 {{- $defaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.http "type" $tier "fullName" $fullName "path" ( include "frost-server.http.serviceSubPath" . ) ) -}}
 {{- /*BEGIN Predefine empty variables*/ -}}
 {{- $annotations := dict -}}
@@ -23,9 +23,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- $annotations = include "common.tplvalues.merge" ( dict "values" ( list .Values.frost.http.ingress.annotations $defaultRewriteAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
-  {{- if .Values.frost.mqtt.ingress.useSameAsHttp }}
-    nginx.org/mergeable-ingress-type: "minion"
-  {{- end }}
+    nginx.org/mergeable-ingress-type: "master"
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -36,7 +34,7 @@ spec:
   {{- if and .Values.frost.http.ingress.ingressClassName (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.frost.http.ingress.ingressClassName }}
   {{- end }}
-  {{- if and .Values.frost.http.ingress.tls.enabled (not .Values.frost.mqtt.ingress.useSameAsHttp)}}
+  {{- if .Values.frost.http.ingress.tls.enabled }}
   tls:
     - hosts: 
         - {{ include "frost-server.http.serviceHost" . }}
@@ -44,13 +42,4 @@ spec:
   {{- end }}
   rules:
   - host: {{ include "frost-server.http.serviceHost" . }}
-    http:
-      paths:
-      - path: {{ template "frost-server.http.serviceSubPath" . }}
-        pathType: Prefix
-        backend:
-          service:
-            name:  {{ $fullName }}
-            port:
-              number: {{ .Values.frost.http.ports.http.servicePort }}
 {{- end -}}

--- a/helm/frost-server/templates/mqtt-ingress.yaml
+++ b/helm/frost-server/templates/mqtt-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.frost.mqtt.ingress.enabled -}}
+{{- if .Values.frost.mqtt.ingress.enabled -}}
 {{- $tier := "mqtt" -}}
 {{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier "merge" .Values.frost.mqtt.ingress.useSameAsHttp ) .) -}}
 {{- $combine := false -}}

--- a/helm/frost-server/templates/mqtt-ingress.yaml
+++ b/helm/frost-server/templates/mqtt-ingress.yaml
@@ -1,14 +1,14 @@
 {{- if and .Values.frost.mqtt.ingress.enabled -}}
 {{- $tier := "mqtt" -}}
-{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
+{{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier "merge" .Values.frost.mqtt.ingress.useSameAsHttp ) .) -}}
 {{- $combine := false -}}
 {{- if .Values.frost.mqtt.ingress.useSameAsHttp -}}
   {{- $combine = .Values.frost.http -}}
 {{- end -}}
 {{- $defaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.mqtt "type" $tier "fullName" $fullName "path" ( include "frost-server.mqtt.websockPath" . ) "combine"  $combine ) -}}
-{{- if and .Values.frost.mqtt.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+{{- if and .Values.frost.mqtt.ingress.ingressClassName (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.frost.mqtt.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.frost.mqtt.ingress.annotations "kubernetes.io/ingress.class" .Values.frost.mqtt.ingress.className}}
+  {{- $_ := set .Values.frost.mqtt.ingress.annotations "kubernetes.io/ingress.class" .Values.frost.mqtt.ingress.ingressClassName}}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -26,7 +26,7 @@ metadata:
   {{- if .Values.frost.mqtt.ingress.useSameAsHttp }}
     nginx.org/mergeable-ingress-type: "minion"
   {{- end }}
-  {{- /*Following annotation can't be described in the _helpers.tpl, so actually it hast to stay here*/ -}}
+  {{- /*Following annotation can't be described in the _helpers.tpl, so actually it has to stay here*/ -}}
   {{- if and (not .Values.frost.mqtt.ingress.useSameAsHttp) (or (eq .Values.frost.mqtt.ingress.ingressProvider "kubernetes-nginx") (not .Values.frost.mqtt.ingress.ingressProvider)) }}
     nginx.ingress.kubernetes.io/server-snippets: |
         location {{ template "frost-server.mqtt.websockPath" . }} {
@@ -47,10 +47,10 @@ metadata:
     app: {{ include "frost-server.name" . }}
     component: {{ $tier }}
 spec:
-  {{- if and .Values.frost.mqtt.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.frost.mqtt.ingress.className | default "nginx" }}
+  {{- if and .Values.frost.mqtt.ingress.ingressClassName (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.frost.mqtt.ingress.ingressClassName | default "nginx" }}
   {{- end }}
-  {{- if .Values.frost.mqtt.ingress.tls.enabled }}
+  {{- if and .Values.frost.mqtt.ingress.tls.enabled (not .Values.frost.mqtt.ingress.useSameAsHttp) }}
   tls:
     - hosts:
         - {{ include "frost-server.mqtt.serviceHost" . }}

--- a/helm/frost-server/templates/mqtt-ingress.yaml
+++ b/helm/frost-server/templates/mqtt-ingress.yaml
@@ -1,7 +1,11 @@
-{{- if and .Values.frost.mqtt.ingress.enabled (not .Values.frost.mqtt.ingress.useSameAsHttp) -}}
+{{- if and .Values.frost.mqtt.ingress.enabled -}}
 {{- $tier := "mqtt" -}}
 {{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
-{{- $defaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.mqtt "type" $tier "fullName" $fullName) -}}
+{{- $combine := false -}}
+{{- if .Values.frost.mqtt.ingress.useSameAsHttp -}}
+  {{- $combine = .Values.frost.http -}}
+{{- end -}}
+{{- $defaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.mqtt "type" $tier "fullName" $fullName "path" ( include "frost-server.mqtt.websockPath" . ) "combine"  $combine ) -}}
 {{- if and .Values.frost.mqtt.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.frost.mqtt.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.frost.mqtt.ingress.annotations "kubernetes.io/ingress.class" .Values.frost.mqtt.ingress.className}}
@@ -19,10 +23,13 @@ metadata:
   name: {{ $fullName }}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.frost.mqtt.ingress.annotations $defaultRewriteAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- if .Values.frost.mqtt.ingress.useSameAsHttp }}
+    nginx.org/mergeable-ingress-type: "minion"
+  {{- end }}
   {{- /*Following annotation can't be described in the _helpers.tpl, so actually it hast to stay here*/ -}}
-  {{- if or (eq .Values.frost.mqtt.ingress.ingressProvider "kubernetes-nginx") (not .Values.frost.mqtt.ingress.ingressProvider) }}
+  {{- if and (not .Values.frost.mqtt.ingress.useSameAsHttp) (or (eq .Values.frost.mqtt.ingress.ingressProvider "kubernetes-nginx") (not .Values.frost.mqtt.ingress.ingressProvider)) }}
     nginx.ingress.kubernetes.io/server-snippets: |
-        location / {
+        location {{ template "frost-server.mqtt.websockPath" . }} {
           proxy_set_header Upgrade $http_upgrade;
           proxy_http_version 1.1;
           proxy_set_header X-Forwarded-Host $http_host;

--- a/helm/frost-server/templates/mqtt-ingress.yaml
+++ b/helm/frost-server/templates/mqtt-ingress.yaml
@@ -28,7 +28,7 @@ metadata:
   {{- end }}
   {{- /*Following annotation can't be described in the _helpers.tpl, so actually it has to stay here*/ -}}
   {{- if and (not .Values.frost.mqtt.ingress.useSameAsHttp) (or (eq .Values.frost.mqtt.ingress.ingressProvider "kubernetes-nginx") (not .Values.frost.mqtt.ingress.ingressProvider)) }}
-    nginx.ingress.kubernetes.io/server-snippets: |
+    nginx.ingress.kubernetes.io/server-snippet: |
         location {{ template "frost-server.mqtt.websockPath" . }} {
           proxy_set_header Upgrade $http_upgrade;
           proxy_http_version 1.1;

--- a/helm/frost-server/templates/mqtt-ingress.yaml
+++ b/helm/frost-server/templates/mqtt-ingress.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.frost.mqtt.ingress.enabled -}}
+{{- if and .Values.frost.mqtt.ingress.enabled (not .Values.frost.mqtt.ingress.useSameAsHttp) -}}
 {{- $tier := "mqtt" -}}
 {{- $fullName := include "frost-server.fullName" (merge (dict "tier" $tier) .) -}}
-{{- $defaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.mqtt "type" "mqtt") -}}
+{{- $defaultRewriteAnnotations := include "frost-server.ingress.rewriteAnnotation" (dict "scope" .Values.frost.mqtt "type" $tier "fullName" $fullName) -}}
 {{- if and .Values.frost.mqtt.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.frost.mqtt.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.frost.mqtt.ingress.annotations "kubernetes.io/ingress.class" .Values.frost.mqtt.ingress.className}}
@@ -17,11 +17,22 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  {{- if not (hasKey .Values.frost.mqtt.ingress.annotations "nginx.org/websocket-services") -}}
-  {{- $_ := set .Values.frost.mqtt.ingress.annotations "nginx.org/websocket-services" $fullName -}}
-  {{- end -}}
   {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.frost.mqtt.ingress.annotations $defaultRewriteAnnotations ) "context" . ) }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $) | nindent 4 }}
+  {{- /*Following annotation can't be described in the _helpers.tpl, so actually it hast to stay here*/ -}}
+  {{- if or (eq .Values.frost.mqtt.ingress.ingressProvider "kubernetes-nginx") (not .Values.frost.mqtt.ingress.ingressProvider) }}
+    nginx.ingress.kubernetes.io/server-snippets: |
+        location / {
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_http_version 1.1;
+          proxy_set_header X-Forwarded-Host $http_host;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header X-Forwarded-For $remote_addr;
+          proxy_set_header Host $host;
+          proxy_set_header Connection "upgrade";
+          proxy_cache_bypass $http_upgrade;
+        }
+  {{- end }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/frost-server/values.yaml
+++ b/helm/frost-server/values.yaml
@@ -264,7 +264,7 @@ frost:
         secretName: []
 
     # FROST-Server MQTT business settings
-    serviceHost: "mqtt.mydomain.com" # default URI is the same then frost.http.serviceHost"
+    serviceHost: "mqtt.mydomain.com" # default URI is overwritten, when mqtt.ingress.useSameAsHttp=true the URI is taken from frost.http.serviceHost"
     urlSubPath: "" # default is mqtt 
     serviceProtocol: http
     qos: 2

--- a/helm/frost-server/values.yaml
+++ b/helm/frost-server/values.yaml
@@ -126,19 +126,19 @@ frost:
         nodePort:
         servicePort: 80
     ingress:
-      enabled: false     
+      enabled: true     
       ## Set a specific ingress-class for the ingress ([default] not set)
-      # className: nginx-hamel
+      ingressClassName: regioit-private-ingress
       ## Defines the type of ingress-Controller in use (kubernetes-nginx [default], nginx-nginx, agic, none ) 
       ## Use "none" to disable render predefined annotations for this service
-      # ingressProvider: "nginx-nginx"
+      ingressProvider: "nginx-nginx"
       ## Additional annotations
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
         cert-manager.io/issue-temporary-certificate: "true"
       tls:
-        enabled: false
-        secretName: []
+        enabled: true
+        secretName: hamel-test-frost-server-http-tls
 
     # FROST-Server HTTP deployment resource option. An empty resources field will default to the limits of the namespace.
     resources:
@@ -161,8 +161,8 @@ frost:
     securityContext:
 
     # FROST-Server HTTP business settings
-    serviceHost: frost-server.example.com
-    urlSubPath: ""
+    serviceHost: frost.hameltest.intern.cnaphci.regioit.cloud
+    urlSubPath: "meinFrost"
     serviceProtocol: http
     servicePort:
     defaultCount: false
@@ -246,25 +246,25 @@ frost:
         message_size: 8092
 
     ingress:
-      enabled: false
+      enabled: true
       ## Set to true to use the same ingress as the HTTP service, otherwise set to false
       ## no dedicated ingress will be created for the MQTT service
-      # useSameAsHttp: true
+      useSameAsHttp: false
       ## Set a specific ingress-class for the ingress ([default] not set)
-      # className: nginx
+      ingressClassName: regioit-private-ingress
       ## Defines the type of ingress-Controller in use (kubernetes-nginx [default], nginx-nginx, agic, none) 
       ## Use "none" to disable render predefined annotations for this service
-      # ingressProvider: "nginx-nginx"
+      ingressProvider: "nginx-nginx"
       ## Additional annotations
-      # annotations:
-      #   cert-manager.io/cluster-issuer: letsencrypt
-      #   cert-manager.io/issue-temporary-certificate: "true"
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+        cert-manager.io/issue-temporary-certificate: "true"
       tls:
-        enabled: false
-        secretName: []
+        enabled: true
+        secretName: hamel-test-frost-server-mqtt-tls
 
     # FROST-Server MQTT business settings
-    serviceHost: "mqtt-server.example.com" # default URI is the same then frost.http.serviceHost"
+    serviceHost: "mqtt.hameltest.intern.cnaphci.regioit.cloud" # default URI is the same then frost.http.serviceHost"
     urlSubPath: "" # default is mqtt 
     serviceProtocol: http
     qos: 2
@@ -308,7 +308,7 @@ frost:
   # FROST-Server Database module configuration #
   ##############################################
   db:
-    enableIntegratedDb: false
+    enableIntegratedDb: true
     dbExternalConnectionString: "jdbc:postgresql://externaldbhost:5432/sensorthings"
     image:
       registry: docker.io

--- a/helm/frost-server/values.yaml
+++ b/helm/frost-server/values.yaml
@@ -128,17 +128,17 @@ frost:
     ingress:
       enabled: true     
       ## Set a specific ingress-class for the ingress ([default] not set)
-      ingressClassName: regioit-private-ingress
+      # ingressClassName: nginx
       ## Defines the type of ingress-Controller in use (kubernetes-nginx [default], nginx-nginx, agic, none ) 
       ## Use "none" to disable render predefined annotations for this service
-      ingressProvider: "nginx-nginx"
+      # ingressProvider: "nginx-nginx"
       ## Additional annotations
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt
-        cert-manager.io/issue-temporary-certificate: "true"
-      tls:
-        enabled: true
-        secretName: hamel-test-frost-server-http-tls
+      # annotations:
+      #   cert-manager.io/cluster-issuer: letsencrypt
+      #   cert-manager.io/issue-temporary-certificate: "true"
+      # tls:
+      #   enabled: true
+      #   secretName: []
 
     # FROST-Server HTTP deployment resource option. An empty resources field will default to the limits of the namespace.
     resources:
@@ -161,8 +161,8 @@ frost:
     securityContext:
 
     # FROST-Server HTTP business settings
-    serviceHost: frost.hameltest.intern.cnaphci.regioit.cloud
-    urlSubPath: "meinFrost"
+    serviceHost: frost.mydomain.com
+    urlSubPath: ""
     serviceProtocol: http
     servicePort:
     defaultCount: false
@@ -251,20 +251,20 @@ frost:
       ## no dedicated ingress will be created for the MQTT service
       useSameAsHttp: false
       ## Set a specific ingress-class for the ingress ([default] not set)
-      ingressClassName: regioit-private-ingress
+      # ingressClassName: nginx
       ## Defines the type of ingress-Controller in use (kubernetes-nginx [default], nginx-nginx, agic, none) 
       ## Use "none" to disable render predefined annotations for this service
-      ingressProvider: "nginx-nginx"
+      # ingressProvider: "nginx-nginx"
       ## Additional annotations
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt
-        cert-manager.io/issue-temporary-certificate: "true"
-      tls:
-        enabled: true
-        secretName: hamel-test-frost-server-mqtt-tls
+      # annotations:
+      #   cert-manager.io/cluster-issuer: letsencrypt
+      #   cert-manager.io/issue-temporary-certificate: "true"
+      # tls:
+      #   enabled: true
+      #   secretName: []
 
     # FROST-Server MQTT business settings
-    serviceHost: "mqtt.hameltest.intern.cnaphci.regioit.cloud" # default URI is the same then frost.http.serviceHost"
+    serviceHost: "mqtt.mydomain.com" # default URI is the same then frost.http.serviceHost"
     urlSubPath: "" # default is mqtt 
     serviceProtocol: http
     qos: 2

--- a/helm/frost-server/values.yaml
+++ b/helm/frost-server/values.yaml
@@ -126,11 +126,11 @@ frost:
         nodePort:
         servicePort: 80
     ingress:
-      enabled: true      
+      enabled: false      
       ## Set a specific ingress-class for the ingress ([default] not set)
       # className: nginx-hamel
-      ## Defines the type of ingress-Controller in use (nginx [default], agic ) 
-      # ingressProvider: agic
+      ## Defines the type of ingress-Controller in use (kubernetes-nginx [default], nginx-nginx, agic ) 
+      # ingressProvider: "nginx-nginx"
       ## Additional annotations
       # annotations:
       #   cert-manager.io/cluster-issuer: letsencrypt
@@ -245,17 +245,18 @@ frost:
         message_size: 8092
 
     ingress:
-      enabled: true      
+      enabled: false
+      ## Set to true to use the same ingress as the HTTP service, otherwise set to false
+      ## no dedicated ingress will be created for the MQTT service
+      # useSameAsHttp: false
       ## Set a specific ingress-class for the ingress ([default] not set)
-      # className: azure-application-gateway
-      ## Defines the type of ingress-Controller in use (nginx [default], agic or traefik) 
-      # ingressProvider: agic
+      # className: nginx
+      ## Defines the type of ingress-Controller in use (kubernetes-nginx [default], nginx-nginx, agic ) 
+      # ingressProvider: "nginx-nginx"
       ## Additional annotations
-      annotations:
-        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-        nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-        # cert-manager.io/cluster-issuer: letsencrypt
-        # cert-manager.io/issue-temporary-certificate: "true"
+      # annotations:
+      #   cert-manager.io/cluster-issuer: letsencrypt
+      #   cert-manager.io/issue-temporary-certificate: "true"
       tls:
         enabled: false
         secretName: []

--- a/helm/frost-server/values.yaml
+++ b/helm/frost-server/values.yaml
@@ -75,7 +75,7 @@ frost:
       enable:
 
   auth:
-    provider:
+    provider: 
     allowAnonymousRead: false
     authenticateOnly:
     role:
@@ -126,15 +126,16 @@ frost:
         nodePort:
         servicePort: 80
     ingress:
-      enabled: false      
+      enabled: false     
       ## Set a specific ingress-class for the ingress ([default] not set)
       # className: nginx-hamel
-      ## Defines the type of ingress-Controller in use (kubernetes-nginx [default], nginx-nginx, agic ) 
+      ## Defines the type of ingress-Controller in use (kubernetes-nginx [default], nginx-nginx, agic, none ) 
+      ## Use "none" to disable render predefined annotations for this service
       # ingressProvider: "nginx-nginx"
       ## Additional annotations
-      # annotations:
-      #   cert-manager.io/cluster-issuer: letsencrypt
-      #   cert-manager.io/issue-temporary-certificate: "true"
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+        cert-manager.io/issue-temporary-certificate: "true"
       tls:
         enabled: false
         secretName: []
@@ -160,7 +161,7 @@ frost:
     securityContext:
 
     # FROST-Server HTTP business settings
-    serviceHost: frost-server
+    serviceHost: frost-server.example.com
     urlSubPath: ""
     serviceProtocol: http
     servicePort:
@@ -248,10 +249,11 @@ frost:
       enabled: false
       ## Set to true to use the same ingress as the HTTP service, otherwise set to false
       ## no dedicated ingress will be created for the MQTT service
-      # useSameAsHttp: false
+      # useSameAsHttp: true
       ## Set a specific ingress-class for the ingress ([default] not set)
       # className: nginx
-      ## Defines the type of ingress-Controller in use (kubernetes-nginx [default], nginx-nginx, agic ) 
+      ## Defines the type of ingress-Controller in use (kubernetes-nginx [default], nginx-nginx, agic, none) 
+      ## Use "none" to disable render predefined annotations for this service
       # ingressProvider: "nginx-nginx"
       ## Additional annotations
       # annotations:
@@ -262,7 +264,7 @@ frost:
         secretName: []
 
     # FROST-Server MQTT business settings
-    serviceHost: "" # default URI is the same then frost.http.serviceHost"
+    serviceHost: "mqtt-server.example.com" # default URI is the same then frost.http.serviceHost"
     urlSubPath: "" # default is mqtt 
     serviceProtocol: http
     qos: 2
@@ -306,7 +308,7 @@ frost:
   # FROST-Server Database module configuration #
   ##############################################
   db:
-    enableIntegratedDb: true
+    enableIntegratedDb: false
     dbExternalConnectionString: "jdbc:postgresql://externaldbhost:5432/sensorthings"
     image:
       registry: docker.io

--- a/helm/frost-server/values.yaml
+++ b/helm/frost-server/values.yaml
@@ -136,9 +136,9 @@ frost:
       # annotations:
       #   cert-manager.io/cluster-issuer: letsencrypt
       #   cert-manager.io/issue-temporary-certificate: "true"
-      # tls:
-      #   enabled: true
-      #   secretName: []
+      tls:
+        enabled: false
+        secretName: []
 
     # FROST-Server HTTP deployment resource option. An empty resources field will default to the limits of the namespace.
     resources:
@@ -259,9 +259,9 @@ frost:
       # annotations:
       #   cert-manager.io/cluster-issuer: letsencrypt
       #   cert-manager.io/issue-temporary-certificate: "true"
-      # tls:
-      #   enabled: true
-      #   secretName: []
+      tls:
+        enabled: false
+        secretName: []
 
     # FROST-Server MQTT business settings
     serviceHost: "mqtt.mydomain.com" # default URI is the same then frost.http.serviceHost"


### PR DESCRIPTION
- possible to use the http-service ingress for http-service and mqtt-websocket-service
  mqtt is listening on <FQDN>/mqtt
  while FROST-Server is listening default on <FQDN>/FROST-Server

- enhancement for mqtt and http-service annotations