### PR TITLE
Align db status url to match docker deployment example

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -28,7 +28,7 @@ If you have docker and docker-compose
 
     ```curl -X POST -H "Content-Type: application/json" -d @demoEntities.json http://localhost:8080/FROST-Server/v1.1/Things```
 
-5. Browse to http://localhost:8080/FROST/DatabaseStatus
+5. Browse to http://localhost:8080/FROST-Server/DatabaseStatus
 6. Click the upgrade button
 7. Browse to http://localhost:8080/FROST-Server/v1.0
 8. Enjoy!

--- a/docs/deployment/postgresql.md
+++ b/docs/deployment/postgresql.md
@@ -35,7 +35,7 @@ The relevant variables are: `persistence.db.url`, `persistence.db.username` and 
 
 After setting up FROST-Server in Docker, Tomcat or Wildfly:
 
-1. Browse to http://localhost:8080/FROST/DatabaseStatus
+1. Browse to http://localhost:8080/FROST-Server/DatabaseStatus
 2. Click the upgrade button
 
 This should initialise/update the database to the latest version and the service is ready for use.

--- a/docs/deployment/tomcat.md
+++ b/docs/deployment/tomcat.md
@@ -97,7 +97,7 @@ For Wildfly, configuration options like the `persistence.persistenceManagerImple
      Using String values for entity ids, with new values generated using uuid_generate_v1mc()
    * `de.fraunhofer.iosb.ilt.sta.persistence.postgres.uuidid.PostgresPersistenceManagerUuid`  
      Using uuid values for entity ids, with new values generated using uuid_generate_v1mc()
-2. Browse to http://localhost:8080/FROST/DatabaseStatus
+2. Browse to http://localhost:8080/FROST-Server/DatabaseStatus
 3. Click the upgrade button
 
 This should initialise/update the database to the latest version and the service is ready for use.


### PR DESCRIPTION
While trying out FROST Server for my first time, I noticed that all examples in the docs use `localhost:8080/FROST-Server`, but the `DatabaseStatus` endpoint is documented to be under `localhost:8080/FROST`. These three occurrences are the only uses of `/FROST` I found in the docs. Looking forward to your feedback!

### Screenshots
When using the default docker-compose example, I get this under the two different endpoints:

**localhost:8080/FROST/DatabaseStatus**
![image](https://github.com/user-attachments/assets/78c76826-8836-4352-bc0c-2f4ff174f13f)

**localhost:8080/FROST-Server/DatabaseStatus**
![image](https://github.com/user-attachments/assets/589d60d9-6842-43b0-9bce-bf0c8aa7a887)
