### PR TITLE
docs: how to protect DatabaseStatus #93

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -33,6 +33,8 @@ If you have docker and docker-compose
 7. Browse to http://localhost:8080/FROST-Server/v1.1
 8. Enjoy!
 
+`/DatabaseStatus` is an admin tool. Do not leave it reachable on a public server without authentication or a reverse proxy. See [Authentication](../settings/auth.md#databasestatus).
+
 
 ## Details
 

--- a/docs/deployment/postgresql.md
+++ b/docs/deployment/postgresql.md
@@ -40,5 +40,7 @@ After setting up FROST-Server in Docker, Tomcat or Wildfly:
 
 This should initialise/update the database to the latest version and the service is ready for use.
 
+`/DatabaseStatus` is an admin tool. Do not leave it reachable on a public server without authentication or a reverse proxy. See [Authentication](../settings/auth.md#databasestatus).
+
 Now you may want to have a look at  [Performance tips for PostgreSQL and PostGIS](db_performance.md).
 

--- a/docs/deployment/tomcat.md
+++ b/docs/deployment/tomcat.md
@@ -102,5 +102,7 @@ For Wildfly, configuration options like the `persistence.persistenceManagerImple
 
 This should initialise/update the database to the latest version and the service is ready for use.
 
+`/DatabaseStatus` is an admin tool. Do not leave it reachable on a public server without authentication or a reverse proxy. See [Authentication](../settings/auth.md#databasestatus).
+
 Now you may want to have a look at [PostgreSQL Setup](postgresql.md) or [Performance tips for PostgreSQL and PostGIS](db_performance.md).
 

--- a/docs/settings/auth.md
+++ b/docs/settings/auth.md
@@ -45,6 +45,12 @@ FROST-Server asks the AuthProvider if the user has the following roles:
 
 Currently there are two auth packages included: `FROST-Server.Auth.Basic` and `FROST-Server.Auth.Keycloak`.
 
+## DatabaseStatus
+
+`/DatabaseStatus` can initialise or upgrade the database. The start page links to it for convenience after install.
+
+If you enable an auth provider, only users with the **admin** role can open it. If you do not enable auth, FROST does not restrict the page — put it behind a reverse proxy (or equivalent) before exposing the server. Without that, anyone who can reach the HTTP port can trigger a database update. They can also create, update, or delete entities, which is a larger risk than DatabaseStatus itself.
+
 
 ## Auth settings
 


### PR DESCRIPTION
Without an auth provider, `/DatabaseStatus` is reachable to anyone who can hit HTTP. With auth, only the admin role can open it.

I documented that on the auth page and added a short warning next to the DatabaseStatus steps in the Docker, Tomcat, and PostgreSQL deployment docs.

Closes #93